### PR TITLE
[49436] Fixed bug where cellular usage preference is not persisted/displayed correctly

### DIFF
--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPageGeneral/SettingsPageGeneralSettingsViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPageGeneral/SettingsPageGeneralSettingsViewController.cs
@@ -54,6 +54,7 @@ namespace NDB.Covid19.iOS.Views.Settings.SettingsPageGeneral
             base.ViewWillAppear(animated);
 
             switchButton.ValueChanged += SwitchValueChanged;
+            SetupSwitchButton();
             SetupLinkButton();
             SetupRadioButtons();
         }
@@ -64,6 +65,11 @@ namespace NDB.Covid19.iOS.Views.Settings.SettingsPageGeneral
 
             switchButton.ValueChanged -= SwitchValueChanged;
             SmittestopLinkButtonStackView.RemoveGestureRecognizer(_gestureRecognizer);
+        }
+        
+        void SetupSwitchButton()
+        {
+            switchButton.On = LocalPreferencesHelper.GetIsDownloadWithMobileDataEnabled();
         }
 
         void SetupLinkButton()
@@ -122,6 +128,10 @@ namespace NDB.Covid19.iOS.Views.Settings.SettingsPageGeneral
                         switchButton.On = true;
                         _viewModel.OnCheckedChange(switchButton.On);
                     });
+            }
+            else
+            {
+                _viewModel.OnCheckedChange(switchButton.On);
             }
         }
 


### PR DESCRIPTION
Fixed two bugs here. One where preference is not set when turning cellular on, and one where value of switch is not displayed according to set preference.