### PR TITLE
[49901] Adjusted spacing on welcome pages

### DIFF
--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/ChildViews/WelcomePageThree.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/ChildViews/WelcomePageThree.storyboard
@@ -22,7 +22,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3824">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="wJw-lM-ZFa">
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="wJw-lM-ZFa">
                                                 <rect key="frame" x="24" y="48" width="366" height="770"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZzF-3E-nm2">
@@ -53,7 +53,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="f7X-20-bjP">
-                                                        <rect key="frame" x="0.0" y="67" width="366" height="50"/>
+                                                        <rect key="frame" x="0.0" y="55" width="366" height="50"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2B1-9B-vpN">
                                                                 <rect key="frame" x="0.0" y="0.0" width="21" height="50"/>
@@ -84,7 +84,7 @@ line 2</string>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="GXc-TR-edu">
-                                                        <rect key="frame" x="0.0" y="141" width="366" height="57.5"/>
+                                                        <rect key="frame" x="0.0" y="117" width="366" height="50"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gNX-cg-Le7">
                                                                 <rect key="frame" x="0.0" y="0.0" width="21" height="50"/>
@@ -105,7 +105,7 @@ line 2</string>
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="14345">
-                                                                <rect key="frame" x="37" y="0.0" width="329" height="37.5"/>
+                                                                <rect key="frame" x="37" y="0.0" width="329" height="40"/>
                                                                 <string key="text">Label
 line 2</string>
                                                                 <fontDescription key="fontDescription" name="Raleway-Regular" family="Raleway" pointSize="16"/>
@@ -114,11 +114,11 @@ line 2</string>
                                                             </label>
                                                         </subviews>
                                                         <constraints>
-                                                            <constraint firstAttribute="bottom" secondItem="14345" secondAttribute="bottom" constant="20" id="62J-ae-6cx"/>
+                                                            <constraint firstAttribute="bottom" secondItem="14345" secondAttribute="bottom" constant="10" id="62J-ae-6cx"/>
                                                         </constraints>
                                                     </stackView>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pbx-HB-rtD">
-                                                        <rect key="frame" x="0.0" y="222.5" width="366" height="107"/>
+                                                        <rect key="frame" x="0.0" y="179" width="366" height="107"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4739">
                                                                 <rect key="frame" x="0.0" y="0.0" width="366" height="113"/>
@@ -163,7 +163,7 @@ line 3</string>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="SF7-wl-LRP">
-                                                        <rect key="frame" x="0.0" y="353.5" width="366" height="416.5"/>
+                                                        <rect key="frame" x="0.0" y="298" width="366" height="472"/>
                                                     </view>
                                                 </subviews>
                                             </stackView>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/Welcome.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/Welcome.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="395">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="395">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1664">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="387.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="407.5"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
                                     <segue destination="1682" kind="embed" identifier="PageViewSegue" id="1714"/>
@@ -63,7 +63,7 @@
                             <constraint firstItem="2561" firstAttribute="leading" secondItem="396" secondAttribute="leadingMargin" id="2563"/>
                             <constraint firstItem="8JH-eT-Ck7" firstAttribute="centerX" secondItem="b5X-h4-uWc" secondAttribute="centerX" id="3454"/>
                             <constraint firstItem="3032" firstAttribute="centerY" secondItem="1671" secondAttribute="centerY" id="7pz-ZJ-6WW"/>
-                            <constraint firstItem="2561" firstAttribute="top" secondItem="1664" secondAttribute="bottom" constant="35" id="DEB-Ok-sdX"/>
+                            <constraint firstItem="2561" firstAttribute="top" secondItem="1664" secondAttribute="bottom" constant="15" id="DEB-Ok-sdX"/>
                             <constraint firstItem="b5X-h4-uWc" firstAttribute="bottom" secondItem="8JH-eT-Ck7" secondAttribute="bottom" constant="38" id="Swg-cu-uvp"/>
                             <constraint firstItem="3032" firstAttribute="trailing" secondItem="1671" secondAttribute="trailing" constant="-12" id="jYQ-ui-kDH"/>
                             <constraint firstItem="8JH-eT-Ck7" firstAttribute="top" secondItem="2561" secondAttribute="bottom" constant="32" id="mH5-VK-bQM"/>


### PR DESCRIPTION
Adjusted spacing on welcome pages to fit content on iPhone 8

Iphone 12 pro max: 
<img width="415" alt="Screenshot 2020-11-24 at 13 28 07" src="https://user-images.githubusercontent.com/19961953/100094601-90b9e100-2e59-11eb-84ea-dfe488808e83.png">
Iphone 8: 
<img width="449" alt="Screenshot 2020-11-24 at 13 28 49" src="https://user-images.githubusercontent.com/19961953/100094607-9283a480-2e59-11eb-85c0-4a6b00a7655a.png">
