### PR TITLE
Fix to font crash in StyleUtils on iOS

### DIFF
--- a/NDB.Covid19/NDB.Covid19.iOS/Info.plist
+++ b/NDB.Covid19/NDB.Covid19.iOS/Info.plist
@@ -61,10 +61,10 @@
 	<key>UIAppFonts</key>
 	<array>
 		<string>Fonts/PTSans-Bold.ttf</string>
-		<string>Fonts/PTSans-Regular.ttf</string>
 		<string>Fonts/PTSans-BoldItalic.ttf</string>
-		<string>Fonts/PTSans-Italic.ttf</string>
 		<string>Fonts/PTSans-Caption-Regular.ttf</string>
+		<string>Fonts/PTSans-Italic.ttf</string>
+		<string>Fonts/PTSans-Regular.ttf</string>
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>

--- a/NDB.Covid19/NDB.Covid19.iOS/NDB.Covid19.iOS.csproj
+++ b/NDB.Covid19/NDB.Covid19.iOS/NDB.Covid19.iOS.csproj
@@ -1040,13 +1040,11 @@
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\Fonts\OFL.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\Fonts\PTSans-Bold.ttf" />
-    <EmbeddedResource Include="Resources\Fonts\PTSans-BoldItalic.ttf" />
-    <EmbeddedResource Include="Resources\Fonts\PTSans-Caption-Regular.ttf" />
-    <EmbeddedResource Include="Resources\Fonts\PTSans-Italic.ttf" />
-    <EmbeddedResource Include="Resources\Fonts\PTSans-Regular.ttf" />
+    <BundleResource Include="Resources\Fonts\PTSans-Regular.ttf" />
+    <BundleResource Include="Resources\Fonts\PTSans-Italic.ttf" />
+    <BundleResource Include="Resources\Fonts\PTSans-Caption-Regular.ttf" />
+    <BundleResource Include="Resources\Fonts\PTSans-BoldItalic.ttf" />
+    <BundleResource Include="Resources\Fonts\PTSans-Bold.ttf" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Some fonts were incorrectly set to EmbeddedResource when they should be BundleResources, which is why it only worked on some devices/simulators.