### PR TITLE
Changed all fonts to be loaded through the PostScript name

### DIFF
--- a/NDB.Covid19/NDB.Covid19.iOS/Utils/StyleUtil.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Utils/StyleUtil.cs
@@ -6,10 +6,10 @@ namespace NDB.Covid19.iOS.Utils
 {
     public static class StyleUtil
     {
-        public static string FontRegularName => "PT Sans";
-        public static string FontBoldName => "PT Sans Bold";
-        public static string FontSemiBoldkName => "PT Sans";
-        public static string FontMediumkName => "PT Sans Caption";
+        public static string FontRegularName => "PTSans-Regular";
+        public static string FontBoldName => "PTSans-Bold";
+        public static string FontSemiBoldkName => "PTSans-Regular";
+        public static string FontMediumkName => "PTSans-Caption";
         public static string FontMonospacedName => "Menlo-Regular";
         public static string FontItalicName => "PTSans-Italic";
 


### PR DESCRIPTION
Changed all fonts to be loaded through the PostScript name, contrary to the documentation.
Tested to be working on iPhone SE 1 Gen 14.2, iPhone 8 13.7/14.2 and iPhone 11 Pro 13.7