### PR TITLE
Merging dev into master to keep updated with all the latest changes 27.11.2020

### DIFF
--- a/NDB.Covid19/NDB.Covid19.Droid/Resources/layout/settings_link.xml
+++ b/NDB.Covid19/NDB.Covid19.Droid/Resources/layout/settings_link.xml
@@ -7,7 +7,7 @@
         android:layout_height="wrap_content"
         tools:showIn="@layout/settings_page">
 
-    <Button
+    <ndb.covid19.droid.views.settings.UnderlinedTextView
             android:id="@+id/settings_link_text"
             style="@style/settings"
             android:layout_width="0dp"
@@ -19,5 +19,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:underlineColor="@color/settingsUnderlineColor"
+            app:underlineWidth="2dp"
+            app:underlineMarginTop="2dp"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/NDB.Covid19/NDB.Covid19.Droid/Resources/values/colors.xml
+++ b/NDB.Covid19/NDB.Covid19.Droid/Resources/values/colors.xml
@@ -37,6 +37,7 @@
     <color name="switchSelectedThumb">#FFFFFF</color>
     <color name="switchUnselectedThumb">#32335F</color>
 	<color name="linkColor">#32345C</color>
+    <color name="settingsUnderlineColor">#fe7668</color>
     
     <color name="infectionStatusButtonOnGreen">#D9F0D4</color>
     <color name="infectionStatusButtonOffRed">#FD9085</color>

--- a/NDB.Covid19/NDB.Covid19.iOS/NDB.Covid19.iOS.csproj
+++ b/NDB.Covid19/NDB.Covid19.iOS/NDB.Covid19.iOS.csproj
@@ -894,6 +894,7 @@
     <Compile Include="IOSDependencyInjectionConfig.cs" />
     <Compile Include="Utils\ColorHelper.cs" />
     <Compile Include="Utils\IOSResetViews.cs" />
+    <Compile Include="Utils\OpenTextViewUrlInWebviewDelegate.cs" />
     <Compile Include="Views\MessagePage\MessagePageCell.cs" />
     <Compile Include="Views\MessagePage\MessagePageCell.designer.cs" />
     <Compile Include="Views\MessagePage\MessagePageViewController.cs" />

--- a/NDB.Covid19/NDB.Covid19.iOS/Utils/ColorHelper.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Utils/ColorHelper.cs
@@ -12,6 +12,7 @@ namespace NDB.Covid19.iOS.Utils
         public static readonly UIColor BURGERMENU_UNDERLINE_COLOR = UIColor.Clear.FromHex(0xF37668);
         public static readonly UIColor INFO_BUTTON_BACKGROUND = UIColor.Clear.FromHex(0xF3F9FB);
         public static readonly UIColor MESSAGE_BORDER_COLOR = UIColor.FromRGB(91, 93, 125);
+        public static readonly UIColor DEFAULT_BACKGROUND_COLOR = UIColor.FromRGB(225, 234, 237);
 
         public static UIColor FromHex(this UIColor color,int hexValue)
         {

--- a/NDB.Covid19/NDB.Covid19.iOS/Utils/OpenTextViewUrlInWebviewDelegate.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Utils/OpenTextViewUrlInWebviewDelegate.cs
@@ -1,0 +1,23 @@
+using CommonServiceLocator;
+using Foundation;
+using NDB.Covid19.Interfaces;
+using UIKit;
+
+namespace NDB.Covid19.iOS.Utils
+{
+    public class OpenTextViewUrlInWebviewDelegate : UITextViewDelegate
+    {
+        private UIViewController Owner { get; set; }
+
+        public OpenTextViewUrlInWebviewDelegate(UIViewController owner)
+        {
+            Owner = owner;
+        }
+
+        public override bool ShouldInteractWithUrl(UITextView textView, NSUrl URL, NSRange characterRange)
+        {
+            ServiceLocator.Current.GetInstance<IBrowser>().OpenAsync(URL);
+            return false;
+        }
+    }
+}

--- a/NDB.Covid19/NDB.Covid19.iOS/Utils/StyleUtil.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Utils/StyleUtil.cs
@@ -6,10 +6,10 @@ namespace NDB.Covid19.iOS.Utils
 {
     public static class StyleUtil
     {
-        public static string FontRegularName => "PT Sans";
-        public static string FontBoldName => "PT Sans Bold";
-        public static string FontSemiBoldkName => "PT Sans";
-        public static string FontMediumkName => "PT Sans Caption";
+        public static string FontRegularName => "PTSans-Regular";
+        public static string FontBoldName => "PTSans-Bold";
+        public static string FontSemiBoldkName => "PTSans-Regular";
+        public static string FontMediumkName => "PTSans-Caption";
         public static string FontMonospacedName => "Menlo-Regular";
         public static string FontItalicName => "PTSans-Italic";
 

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/AuthenticationFlow/Questionnaire.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/AuthenticationFlow/Questionnaire.storyboard
@@ -163,10 +163,10 @@
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6nX-Uu-obQ">
                                                                 <rect key="frame" x="0.0" y="215.5" width="386" height="256"/>
                                                                 <subviews>
-                                                                    <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" translatesAutoresizingMaskIntoConstraints="NO" id="6938">
+                                                                    <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" style="wheels" translatesAutoresizingMaskIntoConstraints="NO" id="6938">
                                                                         <rect key="frame" x="0.0" y="0.0" width="386" height="256"/>
-                                                                        <date key="minimumDate" timeIntervalSinceReferenceDate="599529600">
-                                                                            <!--2020-01-01 00:00:00 +0000-->
+                                                                        <date key="minimumDate" timeIntervalSinceReferenceDate="625881600">
+                                                                            <!--2020-11-01 00:00:00 +0000-->
                                                                         </date>
                                                                     </datePicker>
                                                                 </subviews>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/AuthenticationFlow/QuestionnaireViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/AuthenticationFlow/QuestionnaireViewController.cs
@@ -87,6 +87,7 @@ namespace NDB.Covid19.iOS.Views.AuthenticationFlow
             DateContainer.Layer.BorderColor = ColorHelper.TEXT_COLOR_ON_BACKGROUND.CGColor;
 
             DatePicker.Superview.Layer.CornerRadius = 6;
+            DatePicker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
             DatePicker.MinimumDate = (NSDate)DateTime.SpecifyKind(_viewModel.MinimumDate, DateTimeKind.Utc);
             DatePicker.MaximumDate = (NSDate)DateTime.SpecifyKind(_viewModel.MaximumDate, DateTimeKind.Utc);
 

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/ConsentView/Consent.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/ConsentView/Consent.storyboard
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="LMq-La-7KS">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
@@ -17,122 +17,122 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GrU-6Y-ZGu">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GrU-6Y-ZGu" misplaced="YES">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
-                                    <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="47p-53-WBz">
+                                    <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="47p-53-WBz" misplaced="YES">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ob3-Ud-ZvJ">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="880.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="SbW-O0-GSF">
-                                                        <rect key="frame" x="24" y="48" width="327" height="820.5"/>
+                                                        <rect key="frame" x="25" y="48" width="325" height="820.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="czt-nv-19B">
-                                                                <rect key="frame" x="0.0" y="0.0" width="327" height="20.5"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="kdt-jv-m22">
-                                                                <rect key="frame" x="0.0" y="70.5" width="327" height="750"/>
+                                                                <rect key="frame" x="0.0" y="70.5" width="325" height="750"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Header, about" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tdj-9w-pyz">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Section, about, 1" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4il-OV-dCU">
-                                                                        <rect key="frame" x="0.0" y="40.5" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="40.5" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Section, about, 2" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MgN-i0-Wqq">
-                                                                        <rect key="frame" x="0.0" y="81" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="81" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wiE-rW-LK4" userLabel="Empty Space View">
-                                                                        <rect key="frame" x="0.0" y="121.5" width="327" height="8"/>
+                                                                        <rect key="frame" x="0.0" y="121.5" width="325" height="8"/>
                                                                         <color key="backgroundColor" red="0.0" green="0.1215686275" blue="0.20392156859999999" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="8" id="t8m-Hd-OMk"/>
                                                                         </constraints>
                                                                     </view>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Header, how it works" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0hW-lz-ao8">
-                                                                        <rect key="frame" x="0.0" y="149.5" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="149.5" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Section, how it works, 1" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="drR-l4-1on">
-                                                                        <rect key="frame" x="0.0" y="190" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="190" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Section, how it works, 2" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xM6-fv-s3y">
-                                                                        <rect key="frame" x="0.0" y="230.5" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="230.5" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Section, samtykke, 1" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Inz-PN-qcM">
-                                                                        <rect key="frame" x="0.0" y="271" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="271" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Section, samtykke, 2" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F3P-eC-A0j">
-                                                                        <rect key="frame" x="0.0" y="311.5" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="311.5" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Contact information" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TAq-Lx-eL0">
-                                                                        <rect key="frame" x="0.0" y="352" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="352" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="More information" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y7t-Be-gmn">
-                                                                        <rect key="frame" x="0.0" y="392.5" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="392.5" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kC4-Ra-hyw">
-                                                                        <rect key="frame" x="0.0" y="433" width="327" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="433" width="325" height="30"/>
                                                                         <state key="normal" title="Button"/>
                                                                         <connections>
                                                                             <action selector="PrivacyPolicy_TouchUpInside:" destination="LMq-La-7KS" eventType="touchUpInside" id="2276"/>
                                                                         </connections>
                                                                     </button>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BRJ-kf-cU7" userLabel="Empty Space View">
-                                                                        <rect key="frame" x="0.0" y="483" width="327" height="16"/>
+                                                                        <rect key="frame" x="0.0" y="483" width="325" height="16"/>
                                                                         <color key="backgroundColor" red="0.0" green="0.1215686275" blue="0.20392156859999999" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="16" id="mi2-US-qgK"/>
                                                                         </constraints>
                                                                     </view>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Samtykke bottom, header" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I9E-gI-12f">
-                                                                        <rect key="frame" x="0.0" y="519" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="519" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Samtykke bottom, section" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4yc-NW-VVd">
-                                                                        <rect key="frame" x="0.0" y="559.5" width="327" height="20.5"/>
+                                                                        <rect key="frame" x="0.0" y="559.5" width="325" height="20.5"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <color key="textColor" red="0.19607843459999999" green="0.2039215714" blue="0.36078432199999999" alpha="1" colorSpace="deviceRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XF2-07-HgO" userLabel="Empty Space View">
-                                                                        <rect key="frame" x="0.0" y="600" width="327" height="150"/>
+                                                                        <rect key="frame" x="0.0" y="600" width="325" height="150"/>
                                                                         <color key="backgroundColor" red="0.0" green="0.1215686275" blue="0.20392156859999999" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="150" id="QNc-Rd-cMd"/>
@@ -147,8 +147,8 @@
                                                     </stackView>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstAttribute="trailing" secondItem="SbW-O0-GSF" secondAttribute="trailing" constant="24" id="6nB-3W-ncV"/>
-                                                    <constraint firstItem="SbW-O0-GSF" firstAttribute="leading" secondItem="Ob3-Ud-ZvJ" secondAttribute="leading" constant="24" id="gww-uG-aRF"/>
+                                                    <constraint firstAttribute="trailing" secondItem="SbW-O0-GSF" secondAttribute="trailing" constant="25" id="6nB-3W-ncV"/>
+                                                    <constraint firstItem="SbW-O0-GSF" firstAttribute="leading" secondItem="Ob3-Ud-ZvJ" secondAttribute="leading" constant="25" id="gww-uG-aRF"/>
                                                     <constraint firstItem="SbW-O0-GSF" firstAttribute="top" secondItem="Ob3-Ud-ZvJ" secondAttribute="top" constant="48" id="iUc-wd-T8L"/>
                                                     <constraint firstAttribute="bottom" secondItem="SbW-O0-GSF" secondAttribute="bottom" constant="12" id="zrv-k1-xpr"/>
                                                 </constraints>
@@ -193,10 +193,10 @@
                                 <rect key="frame" x="0.0" y="530" width="375" height="137"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="coo-XW-gbG">
-                                        <rect key="frame" x="27.5" y="67" width="320" height="48"/>
+                                        <rect key="frame" x="25" y="67" width="325" height="48"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fuZ-KK-3g0">
-                                                <rect key="frame" x="0.0" y="0.0" width="156" height="48"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="158.5" height="48"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                 <state key="normal" title="Button">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -206,7 +206,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mzL-na-iZa">
-                                                <rect key="frame" x="164" y="0.0" width="156" height="48"/>
+                                                <rect key="frame" x="166.5" y="0.0" width="158.5" height="48"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                 <state key="normal" title="Button">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -217,12 +217,13 @@
                                             </button>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="mzL-na-iZa" secondAttribute="trailing" id="6u7-wz-Oq5"/>
                                             <constraint firstAttribute="height" constant="48" id="8JQ-LG-RKv"/>
-                                            <constraint firstAttribute="width" constant="320" id="dnE-XJ-Nqi"/>
+                                            <constraint firstItem="fuZ-KK-3g0" firstAttribute="leading" secondItem="coo-XW-gbG" secondAttribute="leading" id="Sdd-NI-o94"/>
                                         </constraints>
                                     </stackView>
                                     <activityIndicatorView hidden="YES" alpha="0.0" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="UK8-LL-nxB">
-                                        <rect key="frame" x="287.5" y="67" width="48" height="48"/>
+                                        <rect key="frame" x="290" y="67" width="48" height="48"/>
                                         <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="48" id="MbF-My-rny"/>
@@ -230,7 +231,7 @@
                                         </constraints>
                                     </activityIndicatorView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="eIy-LP-ph9">
-                                        <rect key="frame" x="27.5" y="14" width="209" height="31"/>
+                                        <rect key="frame" x="46" y="14" width="209" height="31"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Godkend samtykke" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TQu-2i-wXJ">
                                                 <rect key="frame" x="0.0" y="0.0" width="148" height="31"/>
@@ -251,18 +252,23 @@
                                                 </connections>
                                             </switch>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="SWT-nr-2tL" firstAttribute="leading" secondItem="TQu-2i-wXJ" secondAttribute="trailing" constant="10" id="EES-NQ-Xlk"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                                 <viewLayoutGuide key="safeArea" id="OQD-CG-0y7"/>
                                 <color key="backgroundColor" red="0.88235294117647056" green="0.91764705882352937" blue="0.92941176470588238" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
+                                    <constraint firstItem="OQD-CG-0y7" firstAttribute="trailing" secondItem="eIy-LP-ph9" secondAttribute="trailing" constant="120" id="5g7-hH-owF"/>
+                                    <constraint firstItem="OQD-CG-0y7" firstAttribute="trailing" secondItem="coo-XW-gbG" secondAttribute="trailing" constant="25" id="5nd-b1-BSV"/>
+                                    <constraint firstItem="coo-XW-gbG" firstAttribute="leading" secondItem="OQD-CG-0y7" secondAttribute="leading" constant="25" id="7b7-FB-PId"/>
                                     <constraint firstItem="coo-XW-gbG" firstAttribute="top" secondItem="eIy-LP-ph9" secondAttribute="bottom" constant="22" id="OBH-8z-tKa"/>
                                     <constraint firstItem="coo-XW-gbG" firstAttribute="centerX" secondItem="Z6n-P4-w1N" secondAttribute="centerX" id="VZy-bJ-Etc"/>
                                     <constraint firstItem="eIy-LP-ph9" firstAttribute="top" secondItem="OQD-CG-0y7" secondAttribute="top" constant="14" id="X6o-QH-Ffa"/>
                                     <constraint firstItem="UK8-LL-nxB" firstAttribute="centerY" secondItem="mzL-na-iZa" secondAttribute="centerY" id="sJj-52-den"/>
                                     <constraint firstItem="UK8-LL-nxB" firstAttribute="trailing" secondItem="mzL-na-iZa" secondAttribute="trailing" constant="-12" id="snb-lc-EFt"/>
                                     <constraint firstItem="OQD-CG-0y7" firstAttribute="bottom" secondItem="coo-XW-gbG" secondAttribute="bottom" constant="22" id="u9v-lC-REu"/>
-                                    <constraint firstItem="eIy-LP-ph9" firstAttribute="leading" secondItem="coo-XW-gbG" secondAttribute="leading" id="xZ5-4r-9WQ"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBound" value="NO"/>
@@ -320,7 +326,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="z5F-kw-dxa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="82.400000000000006" y="56.221890000000002"/>
+            <point key="canvasLocation" x="82.4" y="56.22189"/>
         </scene>
     </scenes>
     <resources>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/ConsentView/ConsentViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/ConsentView/ConsentViewController.cs
@@ -57,11 +57,12 @@ namespace NDB.Covid19.iOS.Views.ConsentView
             InitButtonStyling(NextBtn, WelcomeViewModel.NEXT_PAGE_BUTTON_TEXT);
             InitButtonSecondaryStyling(BackBtn, WelcomeViewModel.PREVIOUS_PAGE_BUTTON_TEXT);
 
-            WarningLbl.Font = StyleUtil.Font(FontType.FontRegular, 18, 24);
+            WarningLbl.Font = StyleUtil.Font(FontType.FontBold, 22, 24);
             WarningLbl.Text = ConsentViewModel.CONSENT_REQUIRED;
 
             AcceptSwitchBtn.AccessibilityLabel = ConsentViewModel.SWITCH_ACCESSIBILITY_CONSENT_SWITCH_DESCRIPTOR;
             AcceptTextLbl.IsAccessibilityElement = false;
+            AcceptTextLbl.Font = StyleUtil.Font(FontType.FontMedium, 18, 20);
             AcceptTextLbl.Text = ConsentViewModel.GIVE_CONSENT_TEXT;
 
             ActivityIndicator.AccessibilityElementsHidden = true;

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/InfectionStatus/InfectionStatus.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/InfectionStatus/InfectionStatus.storyboard
@@ -30,8 +30,8 @@
                                     <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5I2-pE-NTM">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="677.5"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="duW-YJ-e0x">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="842"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="duW-YJ-e0x">
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="874"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w4F-Ew-Iyy" userLabel="Status View">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="305"/>
@@ -304,7 +304,17 @@
                                                             <constraint firstItem="9yc-jF-FcE" firstAttribute="leading" secondItem="6Ug-II-NMf" secondAttribute="leading" constant="16" id="tFl-vu-hNV"/>
                                                         </constraints>
                                                     </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mW4-37-3XW">
+                                                        <rect key="frame" x="0.0" y="850" width="375" height="24"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="24" id="NAS-98-7at"/>
+                                                        </constraints>
+                                                    </view>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="mW4-37-3XW" firstAttribute="leading" secondItem="duW-YJ-e0x" secondAttribute="leading" id="RcL-CD-2VS"/>
+                                                    <constraint firstAttribute="trailing" secondItem="mW4-37-3XW" secondAttribute="trailing" id="aMy-HI-C1G"/>
+                                                </constraints>
                                             </stackView>
                                         </subviews>
                                         <constraints>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/InfectionStatus/InfectionStatus.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/InfectionStatus/InfectionStatus.storyboard
@@ -116,7 +116,6 @@
                                                                 </subviews>
                                                             </stackView>
                                                         </subviews>
-                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="bottom" secondItem="uaW-Ad-6eY" secondAttribute="bottom" constant="32" id="8WN-A5-T4b"/>
                                                             <constraint firstItem="uaW-Ad-6eY" firstAttribute="top" secondItem="y9k-ec-FSe" secondAttribute="top" constant="32" id="WDw-Zx-vrz"/>
@@ -308,7 +307,6 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstItem="duW-YJ-e0x" firstAttribute="leading" secondItem="5I2-pE-NTM" secondAttribute="leading" id="CH5-Nc-Fss"/>
                                             <constraint firstItem="duW-YJ-e0x" firstAttribute="top" secondItem="5I2-pE-NTM" secondAttribute="top" id="Mxd-Sc-cXJ"/>
@@ -317,7 +315,6 @@
                                         </constraints>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="5I2-pE-NTM" secondAttribute="bottom" id="5q5-HU-HUa"/>
                                     <constraint firstItem="hfb-Su-BUZ" firstAttribute="width" secondItem="5FM-IV-ZSI" secondAttribute="width" id="DwJ-a0-3pK"/>
@@ -330,7 +327,6 @@
                             </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="AvV-Sr-vLn"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="5FM-IV-ZSI" firstAttribute="top" secondItem="AvV-Sr-vLn" secondAttribute="top" id="HF6-lP-dkU"/>
                             <constraint firstItem="5I2-pE-NTM" firstAttribute="width" secondItem="AvV-Sr-vLn" secondAttribute="width" id="T4K-Jx-8fm"/>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/InfectionStatus/InfectionStatusViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/InfectionStatus/InfectionStatusViewController.cs
@@ -72,6 +72,14 @@ namespace NDB.Covid19.iOS.Views.InfectionStatus
             _viewModel.NewMessagesIconVisibilityChanged -= OnNewMessagesIconVisibilityChanged;
             _messageViewBtn.TouchUpInside -= OnMessageBtnTapped;
             _areYouInfectedBtn.TouchUpInside -= OnAreYouInfectedBtnTapped;
+            ResetStatusBar();
+        }
+
+        private void ResetStatusBar()
+        {
+            UIView statusBar = new UIView(UIApplication.SharedApplication.StatusBarFrame);
+            statusBar.BackgroundColor = ColorHelper.DEFAULT_BACKGROUND_COLOR;
+            UIApplication.SharedApplication.KeyWindow.AddSubview(statusBar);
         }
 
         void OnAppReturnsFromBackground(object obj)

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/InfectionStatus/InfectionStatusViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/InfectionStatus/InfectionStatusViewController.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using NDB.Covid19.iOS.Permissions;
 using NDB.Covid19.iOS.Utils;
 using NDB.Covid19.iOS.Views.AuthenticationFlow;
-using NDB.Covid19.iOS.Views.MessagePage;
 using NDB.Covid19.iOS.Views.Settings;
 using NDB.Covid19.Utils;
 using NDB.Covid19.ViewModels;

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage2/SettingsPage2.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage2/SettingsPage2.storyboard
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,13 +18,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="5" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pZa-VB-E56" userLabel="Title Stack View">
-                                <rect key="frame" x="25" y="64" width="369" height="30"/>
+                                <rect key="frame" x="25" y="67" width="389" height="34"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wes-6w-9yE">
-                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="34" height="34"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="30" id="3j3-vZ-5YL"/>
-                                            <constraint firstAttribute="height" constant="30" id="ULZ-Vb-vKA"/>
+                                            <constraint firstAttribute="width" constant="34" id="3j3-vZ-5YL"/>
+                                            <constraint firstAttribute="height" constant="34" id="ULZ-Vb-vKA"/>
                                         </constraints>
                                         <color key="tintColor" red="0.20392156862745098" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
                                         <state key="normal" image="ArrowLeftCircle">
@@ -33,19 +34,27 @@
                                             <action selector="BackButton_TouchUpInside:" destination="555" eventType="touchUpInside" id="27033"/>
                                         </connections>
                                     </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GjL-6J-p5a" userLabel="Spacer">
+                                        <rect key="frame" x="39" y="0.0" width="15" height="0.0"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="15" id="qQ2-uq-nAh"/>
+                                            <constraint firstAttribute="height" id="w74-9v-pnH"/>
+                                        </constraints>
+                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is how it works" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e1O-e9-6PB" customClass="SetttingsPageTitleLabel">
-                                        <rect key="frame" x="35" y="0.0" width="334" height="20.5"/>
+                                        <rect key="frame" x="59" y="0.0" width="330" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.20392156862745098" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="Wes-6w-9yE" firstAttribute="baseline" secondItem="e1O-e9-6PB" secondAttribute="firstBaseline" constant="5" id="glt-u3-npF"/>
+                                    <constraint firstItem="e1O-e9-6PB" firstAttribute="centerY" secondItem="Wes-6w-9yE" secondAttribute="centerY" id="hBi-Bj-EGU"/>
                                 </constraints>
                             </stackView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tYh-1x-HqT">
-                                <rect key="frame" x="0.0" y="114" width="414" height="728"/>
+                                <rect key="frame" x="0.0" y="121" width="414" height="721"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JdS-CA-THG">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="166.5"/>
@@ -90,8 +99,8 @@
                             <constraint firstItem="pZa-VB-E56" firstAttribute="leading" secondItem="lRK-Ep-Hgw" secondAttribute="leading" constant="25" id="IGR-wu-Y2q"/>
                             <constraint firstItem="lRK-Ep-Hgw" firstAttribute="bottom" secondItem="tYh-1x-HqT" secondAttribute="bottom" constant="20" id="bu0-zl-cAX"/>
                             <constraint firstItem="lRK-Ep-Hgw" firstAttribute="leading" secondItem="tYh-1x-HqT" secondAttribute="leading" id="cnf-Fm-sj4"/>
-                            <constraint firstItem="pZa-VB-E56" firstAttribute="top" secondItem="lRK-Ep-Hgw" secondAttribute="top" constant="20" id="lY7-zL-qve"/>
-                            <constraint firstItem="lRK-Ep-Hgw" firstAttribute="trailing" secondItem="pZa-VB-E56" secondAttribute="trailing" constant="20" id="ugD-SA-z3e"/>
+                            <constraint firstItem="pZa-VB-E56" firstAttribute="top" secondItem="lRK-Ep-Hgw" secondAttribute="top" constant="23" id="lY7-zL-qve"/>
+                            <constraint firstItem="lRK-Ep-Hgw" firstAttribute="trailing" secondItem="pZa-VB-E56" secondAttribute="trailing" id="ugD-SA-z3e"/>
                             <constraint firstItem="tYh-1x-HqT" firstAttribute="top" secondItem="pZa-VB-E56" secondAttribute="bottom" constant="20" id="vkC-zh-en2"/>
                             <constraint firstItem="tYh-1x-HqT" firstAttribute="trailing" secondItem="lRK-Ep-Hgw" secondAttribute="trailing" id="zmZ-SI-Pd2"/>
                         </constraints>
@@ -109,5 +118,8 @@
     </scenes>
     <resources>
         <image name="ArrowLeftCircle" width="34" height="34"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage2/SettingsPage2ViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage2/SettingsPage2ViewController.cs
@@ -32,11 +32,6 @@ namespace NDB.Covid19.iOS.Views.Settings.SettingsPage2
             _gestureRecognizer = new UITapGestureRecognizer();
         }
 
-        public override void ViewWillDisappear(bool animated)
-        {
-            base.ViewWillDisappear(animated);
-        }
-
         void SetTexts()
         {
             string intro = SettingsPage2ViewModel.SETTINGS_PAGE_2_CONTENT_TEXT_INTRO;
@@ -67,6 +62,7 @@ namespace NDB.Covid19.iOS.Views.Settings.SettingsPage2
             text.Append(ApplyStylingToText(par2Content, FontType.FontRegular));
             text.Append(ApplyStylingToText(par3Title, FontType.FontBold));
             text.Append(ApplyStylingToText(par3Content, FontType.FontRegular));
+            ContentText.WeakDelegate = new OpenTextViewUrlInWebviewDelegate(this);
             ContentText.AttributedText = text;
             ContentText.WeakLinkTextAttributes =
                 new NSDictionary(

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage3/SettingsPage3.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage3/SettingsPage3.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="632">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="632">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -53,13 +54,13 @@
                                 </constraints>
                             </scrollView>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Z1O-pC-n5q">
-                                <rect key="frame" x="24" y="64" width="342" height="58.5"/>
+                                <rect key="frame" x="25" y="67" width="389" height="55.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="692">
-                                        <rect key="frame" x="0.0" y="14" width="30" height="30"/>
+                                        <rect key="frame" x="0.0" y="10.5" width="34" height="34"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="30" id="0LR-ij-UGK"/>
-                                            <constraint firstAttribute="height" constant="30" id="esE-yM-wtJ"/>
+                                            <constraint firstAttribute="width" constant="34" id="0LR-ij-UGK"/>
+                                            <constraint firstAttribute="height" constant="34" id="esE-yM-wtJ"/>
                                         </constraints>
                                         <color key="tintColor" red="0.1960784314" green="0.20392156859999999" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                         <state key="normal" image="ArrowLeftCircle"/>
@@ -67,20 +68,25 @@
                                             <action selector="BackButton_TouchUpInside:" destination="632" eventType="touchUpInside" id="1705"/>
                                         </connections>
                                     </button>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iBn-mf-h6U" userLabel="Spacer">
-                                        <rect key="frame" x="35" y="29" width="8" height="0.0"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U4I-hw-IHr" userLabel="Spacer">
+                                        <rect key="frame" x="39" y="27.5" width="15" height="0.0"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" id="P8x-Gu-KJY"/>
-                                            <constraint firstAttribute="width" constant="8" id="yEi-1G-KMq"/>
+                                            <constraint firstAttribute="width" constant="15" id="BIr-YP-NHI"/>
+                                            <constraint firstAttribute="height" id="V42-20-N6e"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Consents" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="838" customClass="SetttingsPageTitleLabel">
-                                        <rect key="frame" x="48" y="19" width="294" height="20.5"/>
+                                        <rect key="frame" x="59" y="17.5" width="330" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.1960784314" green="0.20392156859999999" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="692" firstAttribute="centerY" secondItem="Z1O-pC-n5q" secondAttribute="centerY" id="GwD-x8-yZ7"/>
+                                    <constraint firstItem="838" firstAttribute="centerY" secondItem="692" secondAttribute="centerY" id="ksR-jv-U2r"/>
+                                </constraints>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="DXn-IY-jpf" userLabel="Bottom Stack View">
                                 <rect key="frame" x="0.0" y="773.5" width="414" height="122.5"/>
@@ -129,17 +135,17 @@
                         <viewLayoutGuide key="safeArea" id="RHP-9H-xBd"/>
                         <color key="backgroundColor" red="0.88235294119999996" green="0.91764705879999997" blue="0.92941176469999998" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="Z1O-pC-n5q" firstAttribute="top" secondItem="RHP-9H-xBd" secondAttribute="top" constant="20" id="7FH-TV-RLU"/>
+                            <constraint firstItem="Z1O-pC-n5q" firstAttribute="top" secondItem="RHP-9H-xBd" secondAttribute="top" constant="23" id="7FH-TV-RLU"/>
                             <constraint firstItem="DXn-IY-jpf" firstAttribute="leading" secondItem="RHP-9H-xBd" secondAttribute="leading" id="9Jb-lf-blR"/>
                             <constraint firstItem="RHP-9H-xBd" firstAttribute="trailing" secondItem="1031" secondAttribute="trailing" id="Ekh-SC-LAg"/>
                             <constraint firstItem="DXn-IY-jpf" firstAttribute="bottom" secondItem="633" secondAttribute="bottom" id="LSL-dv-eCZ"/>
-                            <constraint firstItem="Z1O-pC-n5q" firstAttribute="leading" secondItem="RHP-9H-xBd" secondAttribute="leading" constant="24" id="POU-Er-sMx"/>
+                            <constraint firstItem="Z1O-pC-n5q" firstAttribute="leading" secondItem="RHP-9H-xBd" secondAttribute="leading" constant="25" id="POU-Er-sMx"/>
                             <constraint firstItem="RHP-9H-xBd" firstAttribute="trailing" secondItem="DXn-IY-jpf" secondAttribute="trailing" id="QSt-ql-fHV"/>
                             <constraint firstItem="DXn-IY-jpf" firstAttribute="height" secondItem="RHP-9H-xBd" secondAttribute="height" multiplier="0.15" id="UPT-rp-cR9"/>
                             <constraint firstItem="DXn-IY-jpf" firstAttribute="top" secondItem="1031" secondAttribute="bottom" id="awf-7F-Lb5"/>
                             <constraint firstItem="1031" firstAttribute="leading" secondItem="RHP-9H-xBd" secondAttribute="leading" id="jWR-ee-o0o"/>
                             <constraint firstItem="1031" firstAttribute="top" secondItem="Z1O-pC-n5q" secondAttribute="bottom" constant="20" id="kK9-IF-Bnx"/>
-                            <constraint firstItem="RHP-9H-xBd" firstAttribute="trailing" secondItem="Z1O-pC-n5q" secondAttribute="trailing" constant="48" id="xG9-ef-U3Y"/>
+                            <constraint firstItem="RHP-9H-xBd" firstAttribute="trailing" secondItem="Z1O-pC-n5q" secondAttribute="trailing" id="xG9-ef-U3Y"/>
                         </constraints>
                     </view>
                     <connections>
@@ -161,5 +167,8 @@
     </scenes>
     <resources>
         <image name="ArrowLeftCircle" width="34" height="34"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage4/SettingsPage4.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage4/SettingsPage4.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="584">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="584">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,13 +18,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="I0h-YT-WTT">
-                                <rect key="frame" x="13" y="64" width="388" height="30"/>
+                                <rect key="frame" x="25" y="67" width="389" height="34"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1169">
-                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="34" height="34"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="30" id="8Ek-1D-s6c"/>
-                                            <constraint firstAttribute="width" constant="30" id="CBq-gt-rna"/>
+                                            <constraint firstAttribute="height" constant="34" id="8Ek-1D-s6c"/>
+                                            <constraint firstAttribute="width" constant="34" id="CBq-gt-rna"/>
                                         </constraints>
                                         <color key="tintColor" red="0.20392156862745098" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
                                         <state key="normal" image="ArrowLeftCircle"/>
@@ -31,19 +32,28 @@
                                             <action selector="BackButton_TouchUpInside:" destination="584" eventType="touchUpInside" id="2060"/>
                                         </connections>
                                     </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j3e-bT-3LY" userLabel="Spacer">
+                                        <rect key="frame" x="39" y="0.0" width="15" height="0.0"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="15" id="OOi-OD-0NS"/>
+                                            <constraint firstAttribute="height" id="UJc-Jo-Q8U"/>
+                                        </constraints>
+                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1170" customClass="SetttingsPageTitleLabel">
-                                        <rect key="frame" x="35" y="0.0" width="353" height="20.5"/>
+                                        <rect key="frame" x="59" y="0.0" width="330" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="1169" firstAttribute="baseline" secondItem="1170" secondAttribute="firstBaseline" constant="5" id="APV-9x-ngS"/>
+                                    <constraint firstItem="1169" firstAttribute="centerY" secondItem="I0h-YT-WTT" secondAttribute="centerY" id="7PX-vb-s6x"/>
+                                    <constraint firstItem="1170" firstAttribute="centerY" secondItem="1169" secondAttribute="centerY" id="pRV-X8-AJM"/>
                                 </constraints>
                             </stackView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oqm-Qq-zTy">
-                                <rect key="frame" x="0.0" y="114" width="414" height="782"/>
+                                <rect key="frame" x="0.0" y="121" width="414" height="775"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EQF-u3-KHz">
                                         <rect key="frame" x="24" y="0.0" width="342" height="200"/>
@@ -99,9 +109,9 @@
                             <constraint firstItem="EQF-u3-KHz" firstAttribute="width" secondItem="CZ0-4X-qcf" secondAttribute="width" constant="-72" id="04w-go-rrn"/>
                             <constraint firstItem="oqm-Qq-zTy" firstAttribute="top" secondItem="I0h-YT-WTT" secondAttribute="bottom" constant="20" id="88s-7i-6g5"/>
                             <constraint firstAttribute="bottom" secondItem="oqm-Qq-zTy" secondAttribute="bottom" id="Id9-Ua-dIJ"/>
-                            <constraint firstItem="I0h-YT-WTT" firstAttribute="top" secondItem="CZ0-4X-qcf" secondAttribute="top" constant="20" id="OdJ-xZ-D2g"/>
-                            <constraint firstItem="I0h-YT-WTT" firstAttribute="leading" secondItem="CZ0-4X-qcf" secondAttribute="leading" constant="13" id="h8l-fA-8vo"/>
-                            <constraint firstItem="CZ0-4X-qcf" firstAttribute="trailing" secondItem="I0h-YT-WTT" secondAttribute="trailing" constant="13" id="q75-Ma-pfX"/>
+                            <constraint firstItem="I0h-YT-WTT" firstAttribute="top" secondItem="CZ0-4X-qcf" secondAttribute="top" constant="23" id="OdJ-xZ-D2g"/>
+                            <constraint firstItem="I0h-YT-WTT" firstAttribute="leading" secondItem="CZ0-4X-qcf" secondAttribute="leading" constant="25" id="h8l-fA-8vo"/>
+                            <constraint firstItem="CZ0-4X-qcf" firstAttribute="trailing" secondItem="I0h-YT-WTT" secondAttribute="trailing" id="q75-Ma-pfX"/>
                             <constraint firstItem="oqm-Qq-zTy" firstAttribute="leading" secondItem="CZ0-4X-qcf" secondAttribute="leading" id="qXn-dC-DuR"/>
                             <constraint firstItem="CZ0-4X-qcf" firstAttribute="trailing" secondItem="oqm-Qq-zTy" secondAttribute="trailing" id="siM-0t-Ywo"/>
                         </constraints>
@@ -121,5 +131,8 @@
     </scenes>
     <resources>
         <image name="ArrowLeftCircle" width="34" height="34"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage4/SettingsPage4ViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage4/SettingsPage4ViewController.cs
@@ -41,6 +41,7 @@ namespace NDB.Covid19.iOS.Views.Settings.SettingsPage4
             string content = urlStringAndText; // + contactsInfo;
 
             ContentText.SetAttributedText(content);
+            ContentText.WeakDelegate = new OpenTextViewUrlInWebviewDelegate(this);
             ContentText.WeakLinkTextAttributes = new NSDictionary(UIStringAttributeKey.ForegroundColor, ColorHelper.TEXT_COLOR_ON_BACKGROUND, UIStringAttributeKey.UnderlineStyle, new NSNumber(1));
 
             //Ensuring text is resiezed correctly when font size is increased

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage5/SettingsPage5.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage5/SettingsPage5.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="569">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="569">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,13 +18,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="yH2-fB-8jI">
-                                <rect key="frame" x="24" y="64" width="377" height="30"/>
+                                <rect key="frame" x="25" y="67" width="389" height="34"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1139">
-                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="34" height="34"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="30" id="9Vs-Tj-AqT"/>
-                                            <constraint firstAttribute="height" constant="30" id="GzZ-KT-DlF"/>
+                                            <constraint firstAttribute="width" constant="34" id="9Vs-Tj-AqT"/>
+                                            <constraint firstAttribute="height" constant="34" id="GzZ-KT-DlF"/>
                                         </constraints>
                                         <color key="tintColor" red="0.1960784314" green="0.20392156859999999" blue="0.36078431370000003" alpha="1" colorSpace="calibratedRGB"/>
                                         <state key="normal" image="ArrowLeftCircle"/>
@@ -31,19 +32,28 @@
                                             <action selector="BackButton_TouchUpInside:" destination="569" eventType="touchUpInside" id="2934"/>
                                         </connections>
                                     </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Syc-Hl-i9z" userLabel="Spacer">
+                                        <rect key="frame" x="39" y="0.0" width="15" height="0.0"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="15" id="kfJ-QJ-dtT"/>
+                                            <constraint firstAttribute="height" id="ql3-Md-IFl"/>
+                                        </constraints>
+                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1154" customClass="SetttingsPageTitleLabel">
-                                        <rect key="frame" x="35" y="0.0" width="342" height="26"/>
+                                        <rect key="frame" x="59" y="0.0" width="330" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="1139" firstAttribute="centerY" secondItem="1154" secondAttribute="centerY" constant="2" id="Iz7-oH-A5A"/>
+                                    <constraint firstItem="1154" firstAttribute="centerY" secondItem="1139" secondAttribute="centerY" id="CIe-1b-6ac"/>
+                                    <constraint firstItem="1139" firstAttribute="centerY" secondItem="yH2-fB-8jI" secondAttribute="centerY" id="M0u-2Q-fNA"/>
                                 </constraints>
                             </stackView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="1169">
-                                <rect key="frame" x="24" y="114" width="366" height="687.5"/>
+                                <rect key="frame" x="24" y="121" width="366" height="680.5"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -64,9 +74,9 @@
                             <constraint firstItem="etF-uc-H6L" firstAttribute="leading" secondItem="1169" secondAttribute="leading" id="0ia-4O-34G"/>
                             <constraint firstItem="etF-uc-H6L" firstAttribute="top" secondItem="1169" secondAttribute="bottom" constant="20" id="1KJ-TN-siF"/>
                             <constraint firstItem="nFY-l9-oHa" firstAttribute="bottom" secondItem="etF-uc-H6L" secondAttribute="bottom" constant="20" id="6GP-JY-IBX"/>
-                            <constraint firstItem="yH2-fB-8jI" firstAttribute="leading" secondItem="nFY-l9-oHa" secondAttribute="leading" constant="24" id="Fn0-zP-ULT"/>
-                            <constraint firstItem="yH2-fB-8jI" firstAttribute="top" secondItem="nFY-l9-oHa" secondAttribute="top" constant="20" id="HEB-Pl-GNT"/>
-                            <constraint firstItem="nFY-l9-oHa" firstAttribute="trailing" secondItem="yH2-fB-8jI" secondAttribute="trailing" constant="13" id="bYW-Q1-1OV"/>
+                            <constraint firstItem="yH2-fB-8jI" firstAttribute="leading" secondItem="nFY-l9-oHa" secondAttribute="leading" constant="25" id="Fn0-zP-ULT"/>
+                            <constraint firstItem="yH2-fB-8jI" firstAttribute="top" secondItem="nFY-l9-oHa" secondAttribute="top" constant="23" id="HEB-Pl-GNT"/>
+                            <constraint firstItem="nFY-l9-oHa" firstAttribute="trailing" secondItem="yH2-fB-8jI" secondAttribute="trailing" id="bYW-Q1-1OV"/>
                             <constraint firstItem="1169" firstAttribute="top" secondItem="yH2-fB-8jI" secondAttribute="bottom" constant="20" id="ggo-wj-XIg"/>
                             <constraint firstItem="etF-uc-H6L" firstAttribute="trailing" secondItem="1169" secondAttribute="trailing" id="k8L-Yq-mdt"/>
                             <constraint firstItem="nFY-l9-oHa" firstAttribute="trailing" secondItem="1169" secondAttribute="trailing" constant="24" id="nuu-D6-ZA2"/>
@@ -87,5 +97,8 @@
     </scenes>
     <resources>
         <image name="ArrowLeftCircle" width="34" height="34"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage5/SettingsPage5ViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPage5/SettingsPage5ViewController.cs
@@ -21,12 +21,14 @@ namespace NDB.Covid19.iOS.Views.Settings.SettingsPage5
 
             HeaderLabel.SetAttributedText(SettingsPage5ViewModel.SETTINGS_PAGE_5_HEADER);
 
-            StyleUtil.InitTextViewWithSpacing(ContentText, FontType.FontRegular, contentText, 1.28, 16, 22);
+            InitTextViewWithSpacing(ContentText, FontType.FontRegular, contentText, 1.28, 16, 22);
 
+            ContentText.WeakDelegate = new OpenTextViewUrlInWebviewDelegate(this);
+            
             //ForegroundColor sets the color of the links. UnderlineStyle determins if the link is underlined, 0 without underline 1 with underline.
             ContentText.WeakLinkTextAttributes = new NSDictionary(UIStringAttributeKey.ForegroundColor, ColorHelper.TEXT_COLOR_ON_BACKGROUND, UIStringAttributeKey.UnderlineStyle, new NSNumber(1));
 
-            StyleUtil.InitLabelWithSpacing(BuildVersionLbl, FontType.FontRegular, SettingsPage5ViewModel.GetVersionInfo(), 1.14, 14, 16);
+            InitLabelWithSpacing(BuildVersionLbl, FontType.FontRegular, SettingsPage5ViewModel.GetVersionInfo(), 1.14, 14, 16);
             BackButton.AccessibilityLabel = SettingsViewModel.SETTINGS_CHILD_PAGE_ACCESSIBILITY_BACK_BUTTON;
 
             ContentText.AccessibilityIdentifier = "contentTextIdentifier";
@@ -36,7 +38,7 @@ namespace NDB.Covid19.iOS.Views.Settings.SettingsPage5
             SetupStyling();
         }
 
-        public void SetupStyling()
+        private void SetupStyling()
         {
             HeaderLabel.TextColor = ColorHelper.TEXT_COLOR_ON_BACKGROUND;
             ContentText.TextColor = ColorHelper.TEXT_COLOR_ON_BACKGROUND;

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPageGeneral/SettingsPageGeneralSettings.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPageGeneral/SettingsPageGeneralSettings.storyboard
@@ -16,71 +16,77 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4744">
-                                <rect key="frame" x="72" y="64" width="292" height="54"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l50-5L-Sdj" userLabel="Top Stack View">
+                                <rect key="frame" x="25" y="67" width="389" height="34"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HSr-7T-Q35">
+                                        <rect key="frame" x="0.0" y="0.0" width="34" height="34"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="34" id="BPd-yK-LkH"/>
+                                            <constraint firstAttribute="height" constant="34" id="R3a-hN-r4h"/>
+                                        </constraints>
+                                        <color key="tintColor" red="0.1960784314" green="0.20392156859999999" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                        <state key="normal" image="ArrowLeftCircle">
+                                            <color key="titleColor" red="0.1960784314" green="0.20392156859999999" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="BackButton_TouchUpInside:" destination="dIo-uC-Pf8" eventType="touchUpInside" id="1032"/>
+                                        </connections>
+                                    </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="v3C-vk-GrE" userLabel="Spacer">
+                                        <rect key="frame" x="34" y="0.0" width="15" height="34"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="15" id="9kY-0w-536"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4744">
+                                        <rect key="frame" x="49" y="0.0" width="340" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" red="0.19607843137254902" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="54" id="16949"/>
+                                    <constraint firstItem="4744" firstAttribute="centerY" secondItem="HSr-7T-Q35" secondAttribute="centerY" id="Y91-JY-IvZ"/>
+                                    <constraint firstItem="HSr-7T-Q35" firstAttribute="centerY" secondItem="l50-5L-Sdj" secondAttribute="centerY" id="YzS-P6-71T"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.19607843137254902" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HSr-7T-Q35">
-                                <rect key="frame" x="26" y="76" width="30" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="30" id="BPd-yK-LkH"/>
-                                    <constraint firstAttribute="height" constant="30" id="R3a-hN-r4h"/>
-                                </constraints>
-                                <color key="tintColor" red="0.1960784314" green="0.20392156859999999" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
-                                <state key="normal" image="ArrowLeftCircle">
-                                    <color key="titleColor" red="0.1960784314" green="0.20392156859999999" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="BackButton_TouchUpInside:" destination="dIo-uC-Pf8" eventType="touchUpInside" id="1032"/>
-                                </connections>
-                            </button>
+                            </stackView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sOZ-87-Hz4">
-                                <rect key="frame" x="0.0" y="130" width="414" height="732"/>
+                                <rect key="frame" x="0.0" y="121" width="414" height="741"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="ySE-4i-zZd">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="559"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="531"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DSR-Ry-lAz" userLabel="Header StackView">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="112"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="84"/>
                                                 <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rIR-7H-zNH" userLabel="Header Label Top spacer">
-                                                        <rect key="frame" x="24" y="0.0" width="366" height="28"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="28" id="pBg-HH-NjS"/>
-                                                        </constraints>
-                                                    </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vSd-ao-W2N">
-                                                        <rect key="frame" x="24" y="28" width="366" height="20.5"/>
+                                                        <rect key="frame" x="24" y="0.0" width="366" height="20.5"/>
                                                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
                                                         <color key="textColor" red="0.19607843137254902" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8y0-Tu-01y" userLabel="Header Label Bottom Spacer">
-                                                        <rect key="frame" x="24" y="48.5" width="366" height="28"/>
+                                                        <rect key="frame" x="24" y="20.5" width="366" height="28"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="28" id="Trv-BP-VJB"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xn8-e9-Lhh" userLabel="Divider">
-                                                        <rect key="frame" x="24" y="76.5" width="366" height="1"/>
+                                                        <rect key="frame" x="24" y="48.5" width="366" height="1"/>
                                                         <color key="backgroundColor" red="0.1960784314" green="0.20392156859999999" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="0.80000000000000004" id="10223"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A6s-Ca-EjE" userLabel="Content Label Top spacer">
-                                                        <rect key="frame" x="24" y="77.5" width="366" height="14"/>
+                                                        <rect key="frame" x="24" y="49.5" width="366" height="14"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="14" id="8P8-77-cNZ"/>
                                                         </constraints>
                                                     </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6La-9L-gry">
-                                                        <rect key="frame" x="24" y="91.5" width="366" height="20.5"/>
+                                                        <rect key="frame" x="24" y="63.5" width="366" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" red="0.19607843137254902" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -89,7 +95,7 @@
                                                 <directionalEdgeInsets key="directionalLayoutMargins" top="0.0" leading="24" bottom="0.0" trailing="24"/>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="oYg-e3-7IU" userLabel="Switch StackView">
-                                                <rect key="frame" x="0.0" y="123" width="414" height="50"/>
+                                                <rect key="frame" x="0.0" y="95" width="414" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="999" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8RN-7I-RZq">
                                                         <rect key="frame" x="24" y="14.5" width="116.5" height="20.5"/>
@@ -115,7 +121,7 @@
                                                 <directionalEdgeInsets key="directionalLayoutMargins" top="0.0" leading="24" bottom="0.0" trailing="24"/>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bdH-Dc-VAI" userLabel="Mobildata Desc and LangLbl StackView">
-                                                <rect key="frame" x="0.0" y="184" width="414" height="85.5"/>
+                                                <rect key="frame" x="0.0" y="156" width="414" height="85.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4cC-xA-F0l">
                                                         <rect key="frame" x="24" y="8" width="366" height="20.5"/>
@@ -151,7 +157,7 @@
                                                 <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="24" bottom="8" trailing="24"/>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="17" translatesAutoresizingMaskIntoConstraints="NO" id="7pW-Ht-muR" userLabel="Radiobutton 1 StackView">
-                                                <rect key="frame" x="0.0" y="280.5" width="414" height="46"/>
+                                                <rect key="frame" x="0.0" y="252.5" width="414" height="46"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="paE-ng-Jam" customClass="CustomRadioButton">
                                                         <rect key="frame" x="24" y="8" width="30" height="30"/>
@@ -174,7 +180,7 @@
                                                 <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="24" bottom="8" trailing="24"/>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="17" translatesAutoresizingMaskIntoConstraints="NO" id="z1M-WW-FaZ" userLabel="Radiobutton 2 StackView">
-                                                <rect key="frame" x="0.0" y="337.5" width="414" height="46"/>
+                                                <rect key="frame" x="0.0" y="309.5" width="414" height="46"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iWr-o6-Ivj" customClass="CustomRadioButton">
                                                         <rect key="frame" x="24" y="8" width="30" height="30"/>
@@ -197,7 +203,7 @@
                                                 <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="24" bottom="8" trailing="24"/>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="17" translatesAutoresizingMaskIntoConstraints="NO" id="r7n-J9-HOV" userLabel="Radiobutton 3 StackView">
-                                                <rect key="frame" x="0.0" y="394.5" width="414" height="46"/>
+                                                <rect key="frame" x="0.0" y="366.5" width="414" height="46"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aa3-S2-gBi" customClass="CustomRadioButton">
                                                         <rect key="frame" x="24" y="8" width="30" height="30"/>
@@ -220,7 +226,7 @@
                                                 <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="24" bottom="8" trailing="24"/>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="lVK-9I-e3e" userLabel="Lang Desc and link StackView">
-                                                <rect key="frame" x="0.0" y="451.5" width="414" height="107.5"/>
+                                                <rect key="frame" x="0.0" y="423.5" width="414" height="107.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="40a-qI-JCe">
                                                         <rect key="frame" x="24" y="8" width="366" height="20.5"/>
@@ -273,16 +279,13 @@
                         <viewLayoutGuide key="safeArea" id="1v0-ri-VsV"/>
                         <color key="backgroundColor" red="0.88235294117647056" green="0.91764705882352937" blue="0.92941176470588238" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="HSr-7T-Q35" firstAttribute="leading" secondItem="Zsk-Gi-bMw" secondAttribute="leadingMargin" constant="6" id="2097"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="4744" secondAttribute="trailing" constant="30" id="17039"/>
-                            <constraint firstItem="4744" firstAttribute="leading" secondItem="HSr-7T-Q35" secondAttribute="trailing" constant="16" id="17128"/>
-                            <constraint firstItem="4744" firstAttribute="top" secondItem="1v0-ri-VsV" secondAttribute="top" constant="20" id="17187"/>
-                            <constraint firstItem="HSr-7T-Q35" firstAttribute="centerY" secondItem="4744" secondAttribute="centerY" id="C2s-rh-Vz7"/>
                             <constraint firstItem="sOZ-87-Hz4" firstAttribute="leading" secondItem="1v0-ri-VsV" secondAttribute="leading" id="Cg5-aM-C5G"/>
-                            <constraint firstItem="HSr-7T-Q35" firstAttribute="leading" secondItem="1v0-ri-VsV" secondAttribute="leading" constant="26" id="TRK-nM-maS"/>
+                            <constraint firstItem="sOZ-87-Hz4" firstAttribute="top" secondItem="l50-5L-Sdj" secondAttribute="bottom" constant="20" id="GGu-TB-qaL"/>
+                            <constraint firstItem="l50-5L-Sdj" firstAttribute="leading" secondItem="1v0-ri-VsV" secondAttribute="leading" constant="25" id="MrT-Oy-Tzf"/>
                             <constraint firstItem="sOZ-87-Hz4" firstAttribute="bottom" secondItem="1v0-ri-VsV" secondAttribute="bottom" id="X2v-VS-V0s"/>
-                            <constraint firstItem="sOZ-87-Hz4" firstAttribute="top" secondItem="4744" secondAttribute="bottom" constant="12" id="cVp-FG-W9K"/>
                             <constraint firstItem="1v0-ri-VsV" firstAttribute="trailing" secondItem="sOZ-87-Hz4" secondAttribute="trailing" id="oIK-h0-1yM"/>
+                            <constraint firstItem="1v0-ri-VsV" firstAttribute="trailing" secondItem="l50-5L-Sdj" secondAttribute="trailing" id="r3v-Nb-FTh"/>
+                            <constraint firstItem="l50-5L-Sdj" firstAttribute="top" secondItem="1v0-ri-VsV" secondAttribute="top" constant="23" id="wAF-Wr-Prh"/>
                         </constraints>
                     </view>
                     <connections>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPageGeneral/SettingsPageGeneralSettingsViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPageGeneral/SettingsPageGeneralSettingsViewController.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using CommonServiceLocator;
 using NDB.Covid19.Enums;
 using NDB.Covid19.Interfaces;

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/ChildViews/WelcomePageFour.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/ChildViews/WelcomePageFour.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="522">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="522">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,19 +20,19 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LP2-fJ-c5c">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="349"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="324"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="BpJ-J8-tvd">
-                                                <rect key="frame" x="24" y="48" width="366" height="301"/>
+                                                <rect key="frame" x="24" y="23" width="366" height="301"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="AvD-Dc-OYG">
                                                         <rect key="frame" x="0.0" y="0.0" width="366" height="73"/>
                                                         <subviews>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sz9-iL-mJ1">
-                                                                <rect key="frame" x="0.0" y="0.0" width="30" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="34" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="height" constant="30" id="ocE-Oy-5hS"/>
-                                                                    <constraint firstAttribute="width" constant="30" id="xHf-Em-EGO"/>
+                                                                    <constraint firstAttribute="height" constant="34" id="ocE-Oy-5hS"/>
+                                                                    <constraint firstAttribute="width" constant="34" id="xHf-Em-EGO"/>
                                                                 </constraints>
                                                                 <color key="tintColor" red="0.19607843137254902" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <state key="normal" image="ArrowLeftCircle"/>
@@ -147,7 +147,7 @@
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="BpJ-J8-tvd" secondAttribute="trailing" constant="24" id="36h-Yf-lWN"/>
-                                            <constraint firstItem="BpJ-J8-tvd" firstAttribute="top" secondItem="LP2-fJ-c5c" secondAttribute="top" constant="48" id="i86-Sy-WTn"/>
+                                            <constraint firstItem="BpJ-J8-tvd" firstAttribute="top" secondItem="LP2-fJ-c5c" secondAttribute="top" constant="23" id="i86-Sy-WTn"/>
                                             <constraint firstItem="BpJ-J8-tvd" firstAttribute="leading" secondItem="LP2-fJ-c5c" secondAttribute="leading" constant="24" id="jrC-xj-h7d"/>
                                             <constraint firstAttribute="bottom" secondItem="BpJ-J8-tvd" secondAttribute="bottom" id="thd-Ac-hgy"/>
                                         </constraints>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/ChildViews/WelcomePageOne.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/ChildViews/WelcomePageOne.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="713">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="713">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,16 +23,16 @@
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="36" translatesAutoresizingMaskIntoConstraints="NO" id="Ulw-xY-s99">
-                                                <rect key="frame" x="24" y="48" width="366" height="770"/>
+                                                <rect key="frame" x="25" y="23" width="364" height="795"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vmj-ld-CVD">
-                                                        <rect key="frame" x="0.0" y="0.0" width="366" height="127"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="364" height="112"/>
                                                         <subviews>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tg5-6b-P0W">
-                                                                <rect key="frame" x="0.0" y="0.0" width="30" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="34" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" constant="30" id="Mdc-v0-7RX"/>
-                                                                    <constraint firstAttribute="height" constant="30" id="q6Q-p0-h9c"/>
+                                                                    <constraint firstAttribute="width" constant="34" id="Mdc-v0-7RX"/>
+                                                                    <constraint firstAttribute="height" constant="34" id="q6Q-p0-h9c"/>
                                                                 </constraints>
                                                                 <color key="tintColor" red="0.19607843137254902" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <state key="normal" image="ArrowLeftCircle"/>
@@ -41,7 +41,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="766">
-                                                                <rect key="frame" x="0.0" y="0.0" width="366" height="112"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="364" height="112"/>
                                                                 <string key="text">Thank
 You
 For contribution</string>
@@ -51,15 +51,15 @@ For contribution</string>
                                                             </label>
                                                         </subviews>
                                                         <constraints>
-                                                            <constraint firstItem="tg5-6b-P0W" firstAttribute="baseline" secondItem="766" secondAttribute="firstBaseline" constant="8" id="c1E-Dz-juI"/>
-                                                            <constraint firstAttribute="bottom" secondItem="766" secondAttribute="bottom" constant="15" id="riZ-1I-H42"/>
+                                                            <constraint firstItem="tg5-6b-P0W" firstAttribute="top" secondItem="766" secondAttribute="top" id="c1E-Dz-juI"/>
+                                                            <constraint firstAttribute="bottom" secondItem="766" secondAttribute="bottom" id="riZ-1I-H42"/>
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="d3v-OM-2Yo">
-                                                        <rect key="frame" x="0.0" y="163" width="366" height="607"/>
+                                                        <rect key="frame" x="0.0" y="148" width="364" height="647"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="wyY-fx-694">
-                                                                <rect key="frame" x="0.0" y="0.0" width="366" height="50"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="364" height="50"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mzO-wa-6Xb">
                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="50"/>
@@ -80,7 +80,7 @@ For contribution</string>
                                                                         </constraints>
                                                                     </view>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="757">
-                                                                        <rect key="frame" x="37" y="0.0" width="329" height="37.5"/>
+                                                                        <rect key="frame" x="37" y="0.0" width="327" height="37.5"/>
                                                                         <string key="text">Label
 line 2</string>
                                                                         <fontDescription key="fontDescription" name="Raleway-Regular" family="Raleway" pointSize="16"/>
@@ -90,7 +90,7 @@ line 2</string>
                                                                 </subviews>
                                                             </stackView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="awd-pJ-UFg">
-                                                                <rect key="frame" x="0.0" y="74" width="366" height="75"/>
+                                                                <rect key="frame" x="0.0" y="74" width="364" height="75"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BUF-6J-Ekb">
                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="50"/>
@@ -111,7 +111,7 @@ line 2</string>
                                                                         </constraints>
                                                                     </view>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="759">
-                                                                        <rect key="frame" x="37" y="0.0" width="329" height="75"/>
+                                                                        <rect key="frame" x="37" y="0.0" width="327" height="75"/>
                                                                         <string key="text">Label line 2
 line 3
 line 4</string>
@@ -122,7 +122,7 @@ line 4</string>
                                                                 </subviews>
                                                             </stackView>
                                                             <view contentMode="scaleToFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="ARs-I2-mbE">
-                                                                <rect key="frame" x="0.0" y="173" width="366" height="434"/>
+                                                                <rect key="frame" x="0.0" y="173" width="364" height="474"/>
                                                             </view>
                                                         </subviews>
                                                     </stackView>
@@ -131,10 +131,10 @@ line 4</string>
                                         </subviews>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="Ulw-xY-s99" secondAttribute="trailing" constant="24" id="9bT-vq-9Ty"/>
+                                            <constraint firstAttribute="trailing" secondItem="Ulw-xY-s99" secondAttribute="trailing" constant="25" id="9bT-vq-9Ty"/>
                                             <constraint firstAttribute="bottom" secondItem="Ulw-xY-s99" secondAttribute="bottom" id="QuK-TM-W3K"/>
-                                            <constraint firstItem="Ulw-xY-s99" firstAttribute="top" secondItem="755" secondAttribute="top" constant="48" id="efe-em-RQg"/>
-                                            <constraint firstItem="Ulw-xY-s99" firstAttribute="leading" secondItem="755" secondAttribute="leading" constant="24" id="xXb-q3-QQe"/>
+                                            <constraint firstItem="Ulw-xY-s99" firstAttribute="top" secondItem="755" secondAttribute="top" constant="23" id="efe-em-RQg"/>
+                                            <constraint firstItem="Ulw-xY-s99" firstAttribute="leading" secondItem="755" secondAttribute="leading" constant="25" id="xXb-q3-QQe"/>
                                         </constraints>
                                     </view>
                                 </subviews>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/ChildViews/WelcomePageThree.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/ChildViews/WelcomePageThree.storyboard
@@ -23,16 +23,16 @@
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="wJw-lM-ZFa">
-                                                <rect key="frame" x="24" y="48" width="366" height="770"/>
+                                                <rect key="frame" x="24" y="23" width="366" height="795"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZzF-3E-nm2">
                                                         <rect key="frame" x="0.0" y="0.0" width="366" height="43"/>
                                                         <subviews>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hP1-Ee-h4f">
-                                                                <rect key="frame" x="0.0" y="0.0" width="30" height="34"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="34" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="height" constant="30" id="8N4-Gc-wlO"/>
-                                                                    <constraint firstAttribute="width" constant="30" id="dRV-qE-ftF"/>
+                                                                    <constraint firstAttribute="height" constant="34" id="8N4-Gc-wlO"/>
+                                                                    <constraint firstAttribute="width" constant="34" id="dRV-qE-ftF"/>
                                                                 </constraints>
                                                                 <color key="tintColor" red="0.19607843137254902" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <state key="normal" image="ArrowLeftCircle"/>
@@ -163,7 +163,7 @@ line 3</string>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="SF7-wl-LRP">
-                                                        <rect key="frame" x="0.0" y="298" width="366" height="472"/>
+                                                        <rect key="frame" x="0.0" y="298" width="366" height="497"/>
                                                     </view>
                                                 </subviews>
                                             </stackView>
@@ -173,7 +173,7 @@ line 3</string>
                                             <constraint firstAttribute="bottom" secondItem="wJw-lM-ZFa" secondAttribute="bottom" id="60C-5r-jGf"/>
                                             <constraint firstAttribute="trailing" secondItem="wJw-lM-ZFa" secondAttribute="trailing" constant="24" id="D7q-Qc-35a"/>
                                             <constraint firstItem="wJw-lM-ZFa" firstAttribute="leading" secondItem="3824" secondAttribute="leading" constant="24" id="KzG-Rd-4zm"/>
-                                            <constraint firstItem="wJw-lM-ZFa" firstAttribute="top" secondItem="3824" secondAttribute="top" constant="48" id="hmm-uQ-sVL"/>
+                                            <constraint firstItem="wJw-lM-ZFa" firstAttribute="top" secondItem="3824" secondAttribute="top" constant="23" id="hmm-uQ-sVL"/>
                                         </constraints>
                                     </view>
                                 </subviews>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/ChildViews/WelcomePageTwo.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/ChildViews/WelcomePageTwo.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="16111">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="16111">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -12,28 +12,27 @@
         <scene sceneID="16110">
             <objects>
                 <viewController id="16111" customClass="WelcomePageTwoViewController" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" ambiguous="YES" id="16112">
+                    <view key="view" contentMode="scaleToFill" id="16112">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="16179">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="16179">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="16632">
-                                        <rect key="frame" x="0.0" y="0.0" width="394" height="818"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="16632">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="36" translatesAutoresizingMaskIntoConstraints="NO" id="KOi-ZI-OJM">
-                                                <rect key="frame" x="24" y="48" width="346" height="770"/>
+                                                <rect key="frame" x="25" y="23" width="364" height="795"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" id="m4U-yP-Obl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="346" height="56"/>
-                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="m4U-yP-Obl">
+                                                        <rect key="frame" x="0.0" y="0.0" width="364" height="56"/>
                                                         <subviews>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uGP-mX-Yqm">
-                                                                <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="34" height="34"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="height" constant="30" id="ehI-CM-VpQ"/>
-                                                                    <constraint firstAttribute="width" constant="30" id="hjq-ih-IwY"/>
+                                                                    <constraint firstAttribute="height" constant="34" id="ehI-CM-VpQ"/>
+                                                                    <constraint firstAttribute="width" constant="34" id="hjq-ih-IwY"/>
                                                                 </constraints>
                                                                 <color key="tintColor" red="0.19607843137254902" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <state key="normal" image="ArrowLeftCircle"/>
@@ -42,23 +41,22 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How the  app works" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="18249">
-                                                                <rect key="frame" x="0.0" y="0.0" width="346" height="56"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="364" height="56"/>
                                                                 <fontDescription key="fontDescription" name="Raleway-Bold" family="Raleway" pointSize="24"/>
                                                                 <color key="textColor" red="0.19607843137254902" green="0.20392156862745098" blue="0.36078431372549019" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                         </subviews>
-                                                        <viewLayoutGuide key="safeArea" id="59f-Ab-0z7"/>
                                                         <constraints>
-                                                            <constraint firstItem="uGP-mX-Yqm" firstAttribute="baseline" secondItem="18249" secondAttribute="firstBaseline" constant="8" id="FhR-IH-Ksk"/>
-                                                            <constraint firstAttribute="bottom" secondItem="18249" secondAttribute="top" constant="70" id="ckI-fm-801"/>
+                                                            <constraint firstItem="uGP-mX-Yqm" firstAttribute="top" secondItem="18249" secondAttribute="top" id="FhR-IH-Ksk"/>
+                                                            <constraint firstAttribute="bottom" secondItem="18249" secondAttribute="bottom" id="ckI-fm-801"/>
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="8X6-Ac-ZdT">
-                                                        <rect key="frame" x="0.0" y="106" width="346" height="664"/>
+                                                        <rect key="frame" x="0.0" y="92" width="364" height="703"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="xTK-3c-dCK">
-                                                                <rect key="frame" x="0.0" y="0.0" width="346" height="50"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="364" height="50"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gKd-XB-1pe">
                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="50"/>
@@ -79,7 +77,7 @@
                                                                         </constraints>
                                                                     </view>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="22296">
-                                                                        <rect key="frame" x="37" y="0.0" width="309" height="37.5"/>
+                                                                        <rect key="frame" x="37" y="0.0" width="327" height="37.5"/>
                                                                         <string key="text">Label
 line 2</string>
                                                                         <fontDescription key="fontDescription" name="Raleway-Regular" family="Raleway" pointSize="16"/>
@@ -89,7 +87,7 @@ line 2</string>
                                                                 </subviews>
                                                             </stackView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="c4w-wb-GDS">
-                                                                <rect key="frame" x="0.0" y="74" width="346" height="50"/>
+                                                                <rect key="frame" x="0.0" y="74" width="364" height="50"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="934-63-rXB">
                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="50"/>
@@ -110,7 +108,7 @@ line 2</string>
                                                                         </constraints>
                                                                     </view>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="22819">
-                                                                        <rect key="frame" x="37" y="0.0" width="309" height="37.5"/>
+                                                                        <rect key="frame" x="37" y="0.0" width="327" height="37.5"/>
                                                                         <string key="text">Label
 line 2</string>
                                                                         <fontDescription key="fontDescription" name="Raleway-Regular" family="Raleway" pointSize="16"/>
@@ -120,7 +118,7 @@ line 2</string>
                                                                 </subviews>
                                                             </stackView>
                                                             <view contentMode="scaleToFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="aIc-wI-zGi">
-                                                                <rect key="frame" x="0.0" y="148" width="346" height="516"/>
+                                                                <rect key="frame" x="0.0" y="148" width="364" height="555"/>
                                                             </view>
                                                         </subviews>
                                                     </stackView>
@@ -129,21 +127,21 @@ line 2</string>
                                         </subviews>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="KOi-ZI-OJM" secondAttribute="trailing" constant="24" id="1a5-U0-X3l"/>
-                                            <constraint firstItem="KOi-ZI-OJM" firstAttribute="leading" secondItem="16632" secondAttribute="leading" constant="24" id="EHF-ff-udI"/>
-                                            <constraint firstItem="KOi-ZI-OJM" firstAttribute="top" secondItem="16632" secondAttribute="top" constant="48" id="LHA-3T-iEa"/>
+                                            <constraint firstAttribute="trailing" secondItem="KOi-ZI-OJM" secondAttribute="trailing" constant="25" id="1a5-U0-X3l"/>
+                                            <constraint firstItem="KOi-ZI-OJM" firstAttribute="leading" secondItem="16632" secondAttribute="leading" constant="25" id="EHF-ff-udI"/>
+                                            <constraint firstItem="KOi-ZI-OJM" firstAttribute="top" secondItem="16632" secondAttribute="top" constant="23" id="LHA-3T-iEa"/>
                                             <constraint firstAttribute="bottom" secondItem="KOi-ZI-OJM" secondAttribute="bottom" id="eOl-A6-aXw"/>
                                         </constraints>
                                     </view>
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="16632" firstAttribute="top" secondItem="16179" secondAttribute="top" id="16825"/>
-                                    <constraint firstItem="16632" firstAttribute="trailing" secondItem="16179" secondAttribute="trailing" id="16890"/>
-                                    <constraint firstItem="16632" firstAttribute="leading" secondItem="16179" secondAttribute="leading" id="16955"/>
-                                    <constraint firstItem="16632" firstAttribute="bottom" secondItem="16179" secondAttribute="bottom" id="17020"/>
-                                    <constraint firstItem="16632" firstAttribute="height" secondItem="16179" secondAttribute="height" priority="250" id="17085"/>
-                                    <constraint firstItem="16632" firstAttribute="width" secondItem="16179" secondAttribute="width" id="br4-gI-hNE"/>
+                                    <constraint firstItem="16632" firstAttribute="width" secondItem="16179" secondAttribute="width" id="Ar5-TS-S1m"/>
+                                    <constraint firstItem="16632" firstAttribute="top" secondItem="16179" secondAttribute="top" id="IHG-Zh-I8F"/>
+                                    <constraint firstAttribute="trailing" secondItem="16632" secondAttribute="trailing" id="MeQ-Vi-B5c"/>
+                                    <constraint firstAttribute="bottom" secondItem="16632" secondAttribute="bottom" id="a9g-L6-WMo"/>
+                                    <constraint firstItem="16632" firstAttribute="height" secondItem="16179" secondAttribute="height" id="b87-DQ-Jzn"/>
+                                    <constraint firstItem="16632" firstAttribute="leading" secondItem="16179" secondAttribute="leading" id="giK-lA-eO3"/>
                                 </constraints>
                             </scrollView>
                         </subviews>
@@ -154,7 +152,6 @@ line 2</string>
                             <constraint firstItem="16109" firstAttribute="top" secondItem="16179" secondAttribute="top" id="17407"/>
                             <constraint firstItem="16109" firstAttribute="trailing" secondItem="16179" secondAttribute="trailing" id="F2R-VH-Uxe"/>
                             <constraint firstItem="16179" firstAttribute="leading" secondItem="16109" secondAttribute="leading" id="hbX-ay-ht2"/>
-                            <constraint firstItem="16179" firstAttribute="width" secondItem="16109" secondAttribute="width" id="vkX-Nl-2qo"/>
                         </constraints>
                     </view>
                     <connections>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/Welcome.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/Welcome.storyboard
@@ -25,29 +25,29 @@
                                 </connections>
                             </containerView>
                             <stackView opaque="NO" contentMode="scaleAspectFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8JH-eT-Ck7">
-                                <rect key="frame" x="4" y="482" width="312" height="48"/>
+                                <rect key="frame" x="25" y="482" width="270" height="48"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2057">
-                                        <rect key="frame" x="0.0" y="0.0" width="152" height="48"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="131" height="48"/>
                                         <state key="normal" title="Button"/>
                                         <connections>
                                             <action selector="PreviousBtn_TouchUpInside:" destination="395" eventType="touchUpInside" id="2104"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1671">
-                                        <rect key="frame" x="160" y="0.0" width="152" height="48"/>
+                                        <rect key="frame" x="139" y="0.0" width="131" height="48"/>
                                         <color key="backgroundColor" systemColor="systemTealColor"/>
                                         <state key="normal" title="Button"/>
                                     </button>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="312" id="3453"/>
-                                    <constraint firstItem="1671" firstAttribute="width" secondItem="8JH-eT-Ck7" secondAttribute="width" multiplier="0.487179" id="n0e-Rb-BJn"/>
+                                    <constraint firstItem="2057" firstAttribute="leading" secondItem="8JH-eT-Ck7" secondAttribute="leading" id="AIy-ge-pfk"/>
+                                    <constraint firstAttribute="trailing" secondItem="1671" secondAttribute="trailing" id="FNT-9f-sa0"/>
                                     <constraint firstAttribute="height" constant="48" id="nMy-oM-zWq"/>
                                 </constraints>
                             </stackView>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="3032">
-                                <rect key="frame" x="284" y="496" width="20" height="20"/>
+                                <rect key="frame" x="263" y="496" width="20" height="20"/>
                                 <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </activityIndicatorView>
                             <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="2561">
@@ -61,10 +61,11 @@
                             <constraint firstItem="b5X-h4-uWc" firstAttribute="trailing" secondItem="1664" secondAttribute="trailing" id="1677"/>
                             <constraint firstItem="2561" firstAttribute="trailing" secondItem="396" secondAttribute="trailingMargin" id="2562"/>
                             <constraint firstItem="2561" firstAttribute="leading" secondItem="396" secondAttribute="leadingMargin" id="2563"/>
-                            <constraint firstItem="8JH-eT-Ck7" firstAttribute="centerX" secondItem="b5X-h4-uWc" secondAttribute="centerX" id="3454"/>
                             <constraint firstItem="3032" firstAttribute="centerY" secondItem="1671" secondAttribute="centerY" id="7pz-ZJ-6WW"/>
                             <constraint firstItem="2561" firstAttribute="top" secondItem="1664" secondAttribute="bottom" constant="15" id="DEB-Ok-sdX"/>
+                            <constraint firstItem="8JH-eT-Ck7" firstAttribute="leading" secondItem="b5X-h4-uWc" secondAttribute="leading" constant="25" id="EbP-25-C7h"/>
                             <constraint firstItem="b5X-h4-uWc" firstAttribute="bottom" secondItem="8JH-eT-Ck7" secondAttribute="bottom" constant="38" id="Swg-cu-uvp"/>
+                            <constraint firstItem="b5X-h4-uWc" firstAttribute="trailing" secondItem="8JH-eT-Ck7" secondAttribute="trailing" constant="25" id="Way-cp-y45"/>
                             <constraint firstItem="3032" firstAttribute="trailing" secondItem="1671" secondAttribute="trailing" constant="-12" id="jYQ-ui-kDH"/>
                             <constraint firstItem="8JH-eT-Ck7" firstAttribute="top" secondItem="2561" secondAttribute="bottom" constant="32" id="mH5-VK-bQM"/>
                             <constraint firstItem="1664" firstAttribute="top" secondItem="b5X-h4-uWc" secondAttribute="top" id="zsf-Xn-PIv"/>
@@ -73,10 +74,9 @@
                     <navigationItem key="navigationItem" title="Title" id="616"/>
                     <connections>
                         <outlet property="ActivityIndicator" destination="3032" id="name-outlet-3032"/>
-                        <outlet property="ButtonsWidthConstraint" destination="3453" id="name-outlet-3453"/>
+                        <outlet property="ButtonsView" destination="8JH-eT-Ck7" id="name-outlet-8JH-eT-Ck7"/>
                         <outlet property="ContainerView" destination="1664" id="name-outlet-1664"/>
                         <outlet property="NextBtn" destination="1671" id="name-outlet-1671"/>
-                        <outlet property="NextBtnWidthConstraint" destination="n0e-Rb-BJn" id="name-outlet-n0e-Rb-BJn"/>
                         <outlet property="PageControl" destination="2561" id="name-outlet-2561"/>
                         <outlet property="PreviousBtn" destination="2057" id="name-outlet-2057"/>
                     </connections>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/WelcomeViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/WelcomeViewController.cs
@@ -70,8 +70,6 @@ namespace NDB.Covid19.iOS.Views.Welcome
             StyleUtil.InitButtonStyling(NextBtn, WelcomeViewModel.NEXT_PAGE_BUTTON_TEXT);
             StyleUtil.InitButtonSecondaryStyling(PreviousBtn, WelcomeViewModel.PREVIOUS_PAGE_BUTTON_TEXT);
             SetPreviousButtonHidden(true);
-            SetNextBtnSize(true);
-
 
             PageControl.UserInteractionEnabled = false;
             PageControl.PageIndicatorTintColor = UIColor.White;
@@ -88,19 +86,32 @@ namespace NDB.Covid19.iOS.Views.Welcome
 
         void SetPreviousButtonHidden(bool hide)
         {
-            PreviousBtn.Alpha = hide ? 0 : 1;
-            ButtonsWidthConstraint.Constant = 320;
-        }
-
-        void SetNextBtnSize (bool resize)
-        {
-            if (_currentPageIndex == 0)
+            if (hide)
             {
-                NextBtnWidthConstraint.Constant = 160;
+                NSLayoutConstraint nextBtnLeadingConstraint = null;
+                foreach (NSLayoutConstraint constraint in ButtonsView.Constraints)
+                {
+                    if (constraint.SecondItem == NextBtn && constraint.SecondAttribute == NSLayoutAttribute.Leading)
+                    {
+                        nextBtnLeadingConstraint = constraint;
+                        break;
+                    }
+                }
+                if (nextBtnLeadingConstraint == null)
+                {
+                    ButtonsView.LeadingAnchor.ConstraintEqualTo(NextBtn.LeadingAnchor, 0).Active = true;
+                }
             }
-            if (_currentPageIndex != 0)
+            else
             {
-                NextBtnWidthConstraint.Constant = 0;
+                foreach (NSLayoutConstraint constraint in ButtonsView.Constraints)
+                {
+                    if (constraint.SecondItem == NextBtn && constraint.SecondAttribute == NSLayoutAttribute.Leading)
+                    {
+                        ButtonsView.RemoveConstraint(constraint);
+                        break;
+                    }
+                }
             }
         }
 
@@ -134,8 +145,6 @@ namespace NDB.Covid19.iOS.Views.Welcome
         void UpdateLayout()
         {
             SetPreviousButtonHidden(_currentPageIndex == 0);
-            SetNextBtnSize(_currentPageIndex == 0);
-            SetNextBtnSize(_currentPageIndex != 0);
             PageControl.CurrentPage = _currentPageIndex;
             PageControl.UpdateCurrentPageDisplay();
 

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/WelcomeViewController.designer.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Welcome/WelcomeViewController.designer.cs
@@ -34,7 +34,7 @@ namespace NDB.Covid19.iOS.Views.Welcome
 
         [Outlet]
         [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.NSLayoutConstraint ButtonsWidthConstraint { get; set; }
+        UIKit.UIStackView ButtonsView { get; set; }
 
         [Outlet]
         [GeneratedCode ("iOS Designer", "1.0")]
@@ -43,10 +43,6 @@ namespace NDB.Covid19.iOS.Views.Welcome
         [Outlet]
         [GeneratedCode ("iOS Designer", "1.0")]
         UIKit.UIButton NextBtn { get; set; }
-
-        [Outlet]
-        [GeneratedCode ("iOS Designer", "1.0")]
-        UIKit.NSLayoutConstraint NextBtnWidthConstraint { get; set; }
 
         [Outlet]
         [GeneratedCode ("iOS Designer", "1.0")]
@@ -71,9 +67,9 @@ namespace NDB.Covid19.iOS.Views.Welcome
                 ActivityIndicator = null;
             }
 
-            if (ButtonsWidthConstraint != null) {
-                ButtonsWidthConstraint.Dispose ();
-                ButtonsWidthConstraint = null;
+            if (ButtonsView != null) {
+                ButtonsView.Dispose ();
+                ButtonsView = null;
             }
 
             if (ContainerView != null) {
@@ -84,11 +80,6 @@ namespace NDB.Covid19.iOS.Views.Welcome
             if (NextBtn != null) {
                 NextBtn.Dispose ();
                 NextBtn = null;
-            }
-
-            if (NextBtnWidthConstraint != null) {
-                NextBtnWidthConstraint.Dispose ();
-                NextBtnWidthConstraint = null;
             }
 
             if (PageControl != null) {

--- a/NDB.Covid19/NDB.Covid19/Locales/en.json
+++ b/NDB.Covid19/NDB.Covid19/Locales/en.json
@@ -94,7 +94,7 @@
   "SETTINGS_PAGE_4_SUPPORT_LINK": "https://www.helsenorge.no/smittestopp",
   "SETTINGS_PAGE_5_HEADER_TEXT": "About Smittestopp",
   "SETTINGS_PAGE_5_CONTENT_TEXT": "The Smittestopp app has been developed by the Norwegian Institute of Public Health in cooperation with Norsk helsenett (NHN)  \nRead more about the app at: ",
-  "SETTINGS_PAGE_5_LINK": "helsenorge.no/en/smittestopp",
+  "SETTINGS_PAGE_5_LINK": "https://www.helsenorge.no/smittestopp",
   "FORCE_UPDATE_MESSAGE": "There is a more recent version of Smittestopp. <br><br> Please update the app to continue.",
   "FORCE_UPDATE_BUTTON_GOOGLE_ANDROID": "Go to Google Play Store",
   "FORCE_UPDATE_BUTTON_HUAWEI_ANDROID": "Go to AppGallery",

--- a/NDB.Covid19/NDB.Covid19/Locales/nb.json
+++ b/NDB.Covid19/NDB.Covid19/Locales/nb.json
@@ -94,7 +94,7 @@
   "SETTINGS_PAGE_4_SUPPORT_LINK": "https://www.helsenorge.no/smittestopp",
   "SETTINGS_PAGE_5_HEADER_TEXT": "Om Smittetopp",
   "SETTINGS_PAGE_5_CONTENT_TEXT": "Smittestopp er utviklet av Folkehelseinstituttet i samarbeid med Norsk helsenett (NHN) \nLes mer om appen på: ",
-  "SETTINGS_PAGE_5_LINK": "helsenorge.no/smittestopp",
+  "SETTINGS_PAGE_5_LINK": "https://www.helsenorge.no/smittestopp",
   "FORCE_UPDATE_MESSAGE": "Det finnes en nyere versjon av Smittestopp. <br><br> Oppdater appen for å fortsette.",
   "FORCE_UPDATE_BUTTON_GOOGLE_ANDROID": "Gå til Google Play Butikk",
   "FORCE_UPDATE_BUTTON_HUAWEI_ANDROID": "Gå til AppGallery",

--- a/NDB.Covid19/NDB.Covid19/Locales/nn.json
+++ b/NDB.Covid19/NDB.Covid19/Locales/nn.json
@@ -94,7 +94,7 @@
   "SETTINGS_PAGE_4_SUPPORT_LINK": "https://www.helsenorge.no/smittestopp",
   "SETTINGS_PAGE_5_HEADER_TEXT": "Om Smittestopp",
   "SETTINGS_PAGE_5_CONTENT_TEXT": "Smittestopp er utvikla av Folkehelseinstituttet i samarbeid med Norsk helsenett (NHN).\nLes meir om appen på:",
-  "SETTINGS_PAGE_5_LINK": "helsenorge.no/smittestopp",
+  "SETTINGS_PAGE_5_LINK": "https://www.helsenorge.no/smittestopp",
   "FORCE_UPDATE_MESSAGE": "Det finst ein nyare versjon av Smittestopp. <br><br> Oppdater appen for å fortsette.",
   "FORCE_UPDATE_BUTTON_GOOGLE_ANDROID": "Gå til Google Play Butikk",
   "FORCE_UPDATE_BUTTON_HUAWEI_ANDROID": "Gå til AppGallery",

--- a/NDB.Covid19/NDB.Covid19/ViewModels/QuestionnaireViewModel.cs
+++ b/NDB.Covid19/NDB.Covid19/ViewModels/QuestionnaireViewModel.cs
@@ -59,7 +59,7 @@ namespace NDB.Covid19.ViewModels
         static DateTime _selectedDateUTC { get; set; }
         static DateTime _localSelectedDate => DateTime.SpecifyKind(_selectedDateUTC, DateTimeKind.Utc).ToLocalTime();
         public static QuestionaireSelection Selection { get; private set; } = QuestionaireSelection.Skip;
-        public DateTime MinimumDate { get; private set; } = new DateTime(2020, 1, 1, 0, 0, 0).ToUniversalTime();
+        public DateTime MinimumDate { get; private set; } = new DateTime(2020, 11, 1, 0, 0, 0).ToUniversalTime();
         public DateTime MaximumDate { get; private set; } = DateTime.Today.ToUniversalTime();
 
         public string RadioButtonAccessibilityDatepicker => REGISTER_QUESTIONAIRE_SYMPTOMONSET_ANSWER_YES + ". " + REGISTER_QUESTIONAIRE_ACCESSIBILITY_RADIO_BUTTON_DATEPICKER_TEXT + ". " + REGISTER_QUESTIONAIRE_ACCESSIBILITY_RADIO_BUTTON_1_TEXT;


### PR DESCRIPTION
Fix no underline in settings (#49)
[50024] iOS: Unified layouts in settings and welcome pages (#45)
Fixed issue with background color in InfectionStatus page (#52)
Enforcing wheels to be a preffered datepicker style and setting minimum date for symtoms onset date to be 1st of November (#53)
[49849] Add padding to the bottom of Infection Status page (#54)
Fixed issue where status bar color from InfectionStatus page persisted to other pages (#55)
Fixed margin issue on consent page appearing on iPhone SE Gen 1 (#57)
[50160] Bugfix - Fixed url in 'About' page (#58)
[50156] iOS: Unify links behaviour in Settings (#59)
Changed all fonts to be loaded through the PostScript name, contrary to the documentation. (#60)