### PR TITLE
[50426] Optimize MarkAllAsRead method and add unit test

### DIFF
--- a/NDB.Covid19/NDB.Covid19.Test/Tests/Utils/MessageUtilsTests.cs
+++ b/NDB.Covid19/NDB.Covid19.Test/Tests/Utils/MessageUtilsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using CommonServiceLocator;
@@ -161,6 +162,18 @@ namespace NDB.Covid19.Test.Tests.Utils
             messagesAfterMark.Should().HaveCount(2);
 
             messagesAfterMark.All(message => message.IsRead == false).Should().BeTrue();
+        }
+        
+        [Fact]
+        [BeforeAfterAttr]
+        public async void GetMarkAllAsReadShouldMarkAllMessagesAsRead()
+        {
+            MessageUtils.MarkAllAsRead();
+
+            List<MessageSQLiteModel> messagesAfterMark = await MessageUtils.GetAllUnreadMessages();
+            messagesAfterMark.Should().HaveCount(0);
+
+            messagesAfterMark.All(message => message.IsRead).Should().BeTrue();
         }
     }
 }

--- a/NDB.Covid19/NDB.Covid19/PersistedData/SQLite/IMessagesManager.cs
+++ b/NDB.Covid19/NDB.Covid19/PersistedData/SQLite/IMessagesManager.cs
@@ -12,5 +12,7 @@ namespace NDB.Covid19.PersistedData.SQLite
         Task DeleteMessages(List<MessageSQLiteModel> logs);
         Task DeleteAll();
         Task MarkAsRead(MessageSQLiteModel message, bool isRead);
+        Task MarkAllAsRead();
+
     }
 }

--- a/NDB.Covid19/NDB.Covid19/Utils/MessageUtils.cs
+++ b/NDB.Covid19/NDB.Covid19/Utils/MessageUtils.cs
@@ -23,14 +23,15 @@ namespace NDB.Covid19.Utils
         static string DEFAULT_MESSAGE_TITLE => "MESSAGES_MESSAGE_HEADER";
         static string DEFAULT_MESSAGE_LINK => "MESSAGES_LINK";
 
-        private static async Task CreateAndSaveNewMessage(object Sender, DateTime? customTime = null, int triggerAfterNSec = 0)
+        private static async Task CreateAndSaveNewMessage(object Sender, DateTime? customTime = null,
+            int triggerAfterNSec = 0)
         {
             //When creating a message
             MessageSQLiteModel messageSqLiteModel = new MessageSQLiteModel()
             {
                 IsRead = false,
                 MessageLink = DEFAULT_MESSAGE_LINK,
-                TimeStamp = customTime ?? DateTime.Now,
+                TimeStamp = customTime ?? SystemTime.Now(),
                 Title = DEFAULT_MESSAGE_TITLE
             };
 
@@ -51,7 +52,7 @@ namespace NDB.Covid19.Utils
                     customTime ?? SystemTime.Now(),
                     nameof(CreateAndSaveNewMessage));
             }
-        } 
+        }
 
         public static async Task CreateMessage(object Sender, DateTime? customTime = null, int triggerAfterNSec = 0)
         {
@@ -67,7 +68,7 @@ namespace NDB.Covid19.Utils
         {
             IEnumerable<MessageSQLiteModel> messages =
                 (await _manager.GetMessages())
-                    .OrderByDescending(x => x.TimeStamp);
+                .OrderByDescending(x => x.TimeStamp);
             return messages.ToList();
         }
 
@@ -88,15 +89,20 @@ namespace NDB.Covid19.Utils
 
         public static async Task RemoveAllOlderThan(int minutes)
         {
-            var messages = await GetMessages();
-            var messagesToRemove = messages
-                .FindAll(message => DateTime.Now.Subtract(message.TimeStamp).TotalMinutes >= minutes).ToList();
+            List<MessageSQLiteModel> messages = await GetMessages();
+            List<MessageSQLiteModel> messagesToRemove = messages
+                .FindAll(message => SystemTime.Now().Subtract(message.TimeStamp).TotalMinutes >= minutes).ToList();
             await RemoveMessages(messagesToRemove);
         }
 
         public static void MarkAsRead(MessageItemViewModel message, bool isRead)
         {
             _manager.MarkAsRead(new MessageSQLiteModel(message), isRead);
+        }
+
+        public static void MarkAllAsRead()
+        {
+            _manager.MarkAllAsRead();
         }
 
         public static List<MessageItemViewModel> ToMessageItemViewModelList(List<MessageSQLiteModel> list)
@@ -106,7 +112,8 @@ namespace NDB.Covid19.Utils
 
         public static bool HasCreatedMessageAndNotificationToday()
         {
-            DateTime lastRiskAlertUtc = GetDateTimeFromSecureStorageForKey(SecureStorageKeys.LAST_HIGH_RISK_ALERT_UTC_KEY, nameof(HasCreatedMessageAndNotificationToday));
+            DateTime lastRiskAlertUtc = GetDateTimeFromSecureStorageForKey(
+                SecureStorageKeys.LAST_HIGH_RISK_ALERT_UTC_KEY, nameof(HasCreatedMessageAndNotificationToday));
             return lastRiskAlertUtc.Date == SystemTime.Now().Date;
         }
 
@@ -117,7 +124,8 @@ namespace NDB.Covid19.Utils
         /// <param name="DateTimeToSave"></param>
         /// <param name="CallerMethodToLogError"></param>
         /// <returns></returns>
-        public static void SaveDateTimeToSecureStorageForKey(string SecureStorageKey, DateTime DateTimeToSave, string CallerMethodToLogError)
+        public static void SaveDateTimeToSecureStorageForKey(string SecureStorageKey, DateTime DateTimeToSave,
+            string CallerMethodToLogError)
         {
             try
             {
@@ -135,7 +143,8 @@ namespace NDB.Covid19.Utils
         /// <param name="SecureStorageKey"></param>
         /// <param name="CallerMethodToLogError"></param>
         /// <returns></returns>
-        public static DateTime GetDateTimeFromSecureStorageForKey(string SecureStorageKey, string CallerMethodToLogError)
+        public static DateTime GetDateTimeFromSecureStorageForKey(string SecureStorageKey,
+            string CallerMethodToLogError)
         {
             DateTime DateTimeFromSecureStorage;
             try
@@ -154,6 +163,7 @@ namespace NDB.Covid19.Utils
                 LogUtils.LogException(Enums.LogSeverity.ERROR, e, $"{_logPrefix}.{CallerMethodToLogError}");
                 DateTimeFromSecureStorage = DateTime.UtcNow.AddDays(-100); // Date far in the past
             }
+
             return DateTimeFromSecureStorage;
         }
     }

--- a/NDB.Covid19/NDB.Covid19/ViewModels/MessagesViewModel.cs
+++ b/NDB.Covid19/NDB.Covid19/ViewModels/MessagesViewModel.cs
@@ -49,14 +49,7 @@ namespace NDB.Covid19.ViewModels
 
         public static async Task MarkAllMessagesAsRead()
         {
-            var messages = await GetMessages();
-            foreach (var message in messages)
-            {
-                if (message.IsRead == false)
-                {
-                    message.IsRead = true;
-                }
-            }
+            MessageUtils.MarkAllAsRead();
             MessagingCenter.Send(Subscriber, MessagingCenterKeys.KEY_MESSAGE_STATUS_UPDATED);
         }
     }


### PR DESCRIPTION
Previous implementation was marking all messages separately in separate session and getting of messages list was also in separate session. That could take to much time. This change moves getting of messages and marking of elements to one session. 