### PR TITLE
[50661] iOS: Missing underline on bottom text of general settings

### DIFF
--- a/NDB.Covid19/NDB.Covid19.iOS/Utils/StyleUtil.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Utils/StyleUtil.cs
@@ -124,6 +124,22 @@ namespace NDB.Covid19.iOS.Utils
         /// </summary>
         /// <param name="label"></param>
         /// <param name="fontType"></param>
+        /// <param name="text"></param>
+        /// <param name="fontSize"></param>
+        /// <param name="maxFontSize"></param>
+        public static void InitUnderlinedLabel(UILabel label, FontType fontType, string text, float fontSize, float maxFontSize)
+        {
+            var attributedString = new NSMutableAttributedString(text);
+            attributedString.AddAttribute(UIStringAttributeKey.UnderlineStyle, NSNumber.FromInt32((int)NSUnderlineStyle.Single), new NSRange(0, attributedString.Length));
+            label.AttributedText = attributedString;
+            label.Font = Font(fontType, fontSize, maxFontSize);
+        }
+
+        /// <summary>
+        /// Set maxFontSize for accessibility - large text
+        /// </summary>
+        /// <param name="label"></param>
+        /// <param name="fontType"></param>
         /// <param name="rawText"></param>
         /// <param name="lineHeight"></param>
         /// <param name="fontSize"></param>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPageGeneral/SettingsPageGeneralSettingsViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/Settings/SettingsPageGeneral/SettingsPageGeneralSettingsViewController.cs
@@ -43,7 +43,7 @@ namespace NDB.Covid19.iOS.Views.Settings.SettingsPageGeneral
 
             InitLabel(RestartAppLabl, FontType.FontRegular,
                 SettingsGeneralViewModel.SETTINGS_GENERAL_RESTART_REQUIRED_TEXT, 14, 28);
-            InitLabel(SmittestopLinkButtonLbl, FontType.FontRegular,
+            InitUnderlinedLabel(SmittestopLinkButtonLbl, FontType.FontRegular,
                 SettingsGeneralViewModel.SETTINGS_GENERAL_MORE_INFO_BUTTON_TEXT, 16, 28);
 
             Header.TextColor = ColorHelper.TEXT_COLOR_ON_BACKGROUND;


### PR DESCRIPTION
- Created method for initializing and underlined label in StyleUtils
- Changed bottom text in general settings to underlined text