### PR TITLE
[51206] Android: Implemented colored outline on main page button when focused

### DIFF
--- a/NDB.Covid19/NDB.Covid19.Droid/Resources/drawable/ic_default_button.xml
+++ b/NDB.Covid19/NDB.Covid19.Droid/Resources/drawable/ic_default_button.xml
@@ -10,6 +10,7 @@
     <shape android:shape="rectangle"  >
       <corners android:radius="@dimen/button_radius" />
       <solid android:color="@color/colorPrimary"/>
+      <stroke android:color="@color/colorAccent" android:width="@dimen/mtrl_btn_stroke_size" />
     </shape>
   </item>
   <item android:state_enabled="false" android:color="@color/greyedOut">

--- a/NDB.Covid19/NDB.Covid19.Droid/Resources/drawable/ic_secondary_button.xml
+++ b/NDB.Covid19/NDB.Covid19.Droid/Resources/drawable/ic_secondary_button.xml
@@ -7,9 +7,9 @@
         </shape>
     </item>
     <item android:state_focused="true">
-        <shape android:shape="rectangle"  >
+        <shape android:shape="rectangle">
             <corners android:radius="@dimen/button_radius" />
-            <stroke android:width="1dip" android:color="@color/colorPrimary" />
+            <stroke android:color="?android:attr/colorAccent" android:width="@dimen/mtrl_btn_stroke_size" />
         </shape>
     </item>  
     <item >


### PR DESCRIPTION
<img width="373" alt="Screenshot 2020-12-18 at 11 33 52" src="https://user-images.githubusercontent.com/19961953/102605379-7b1c9c00-4125-11eb-9a93-b5eab470e26a.png">
<img width="372" alt="Screenshot 2020-12-18 at 11 36 22" src="https://user-images.githubusercontent.com/19961953/102605383-7ce65f80-4125-11eb-8cac-68fa2d1a321f.png">
<img width="371" alt="Screenshot 2020-12-18 at 11 32 10" src="https://user-images.githubusercontent.com/19961953/102605394-81ab1380-4125-11eb-82b8-343b0ca9ee3d.png">
<img width="371" alt="Screenshot 2020-12-18 at 11 31 46" src="https://user-images.githubusercontent.com/19961953/102605399-8374d700-4125-11eb-8064-28fde3226053.png">
