### PR TITLE
WIP [ExPR 001] Change 'må'/'must' to 'kan'/may'

### DIFF
--- a/NDB.Covid19/NDB.Covid19/Locales/en.json
+++ b/NDB.Covid19/NDB.Covid19/Locales/en.json
@@ -245,7 +245,7 @@
   "SETTINGS_GENERAL_TITLE": "Settings",
   "SETTINGS_GENERAL_EXPLANATION_ONE": "Edit your settings",
   "SETTINGS_GENERAL_EXPLANATION_TWO": "Access to mobile data ",
-  "SETTINGS_GENERAL_MOBILE_DATA_HEADER": "Smittestopp must have access to mobile data ",
+  "SETTINGS_GENERAL_MOBILE_DATA_HEADER": "Smittestopp may have access to mobile data ",
   "SETTINGS_GENERAL_MOBILE_DATA_DESC": "When you turn off mobile data here, you can control your data usage. If you choose to turn off mobile data, information about infected people you have been nearby to is only obtained when you have a Wi-Fi connection. The app remains active even if you choose to turn off mobile data.",
   "SETTINGS_GENERAL_CHOOSE_LANGUAGE_HEADER": "Choose language / Velg språk ",
   "SETTINGS_GENERAL_NB": "Bokmål",

--- a/NDB.Covid19/NDB.Covid19/Locales/nb.json
+++ b/NDB.Covid19/NDB.Covid19/Locales/nb.json
@@ -245,7 +245,7 @@
   "SETTINGS_GENERAL_TITLE": "Innstillinger ",
   "SETTINGS_GENERAL_EXPLANATION_ONE": "Her kan du redigere innstillingene dine",
   "SETTINGS_GENERAL_EXPLANATION_TWO": "Tilgang til mobildata",
-  "SETTINGS_GENERAL_MOBILE_DATA_HEADER": "Smittestopp må få tilgang til mobildata",
+  "SETTINGS_GENERAL_MOBILE_DATA_HEADER": "Smittestopp kan få tilgang til mobildata",
   "SETTINGS_GENERAL_MOBILE_DATA_DESC": "Når du slår av mobildata her, kan du styre dataforbruket fordi det da bare hentes opplysninger om smittede du har vært i nærheten av når du er på wifi. Appen er fortsatt aktiv selv om du slår av mobildata.",
   "SETTINGS_GENERAL_CHOOSE_LANGUAGE_HEADER": "Velg språk / Choose language ",
   "SETTINGS_GENERAL_NB": "Bokmål",

--- a/NDB.Covid19/NDB.Covid19/Locales/nn.json
+++ b/NDB.Covid19/NDB.Covid19/Locales/nn.json
@@ -245,7 +245,7 @@
   "SETTINGS_GENERAL_TITLE": "Innstillingar ",
   "SETTINGS_GENERAL_EXPLANATION_ONE": "Her kan du redigere innstillingane dine",
   "SETTINGS_GENERAL_EXPLANATION_TWO": "Tilgang til mobildata",
-  "SETTINGS_GENERAL_MOBILE_DATA_HEADER": "Smittestopp må få tilgang til mobildata",
+  "SETTINGS_GENERAL_MOBILE_DATA_HEADER": "Smittestopp kan få tilgang til mobildata",
   "SETTINGS_GENERAL_MOBILE_DATA_DESC": "Når du slår av mobildata her, kan du styre databruken din, sidan det da berre blir henta informasjon om smitta du har vore i nærleiken av når du har vore tilkopla Wi-Fi. Appen er aktiv sjølv om du slår av mobildata.",
   "SETTINGS_GENERAL_CHOOSE_LANGUAGE_HEADER": "Vel språk / Choose language ",
   "SETTINGS_GENERAL_NB": "Bokmål",


### PR DESCRIPTION
The information in the current string "Smittestopp must have access to mobile data" is in conflict with the information on the next string ("When you turn off mobile data here, you can control your data usage. If you choose to turn off mobile data, information about infected people you have been nearby to is only obtained when you have a Wi-Fi connection. The app remains active even if you choose to turn off mobile data.")

Knowing that this is based on a danish language app, this looks like a mistranslation from danish 'må'. The correct translation from danish 'må' would be english 'may' or norwegian 'kan'.