### PR TITLE
New AnonymousTokens feature flag and updated property namings

### DIFF
--- a/NDB.Covid19/NDB.Covid19.Test/NDB.Covid19.Test.csproj
+++ b/NDB.Covid19/NDB.Covid19.Test/NDB.Covid19.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AnonymousTokens.Server" Version="1.3.0" />
+    <PackageReference Include="AnonymousTokens.Server" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.13.1" />

--- a/NDB.Covid19/NDB.Covid19.Test/Tests/WebServices/AnonymousTokenServiceTest.cs
+++ b/NDB.Covid19/NDB.Covid19.Test/Tests/WebServices/AnonymousTokenServiceTest.cs
@@ -31,7 +31,8 @@ namespace NDB.Covid19.Test.Tests.WebServices
 
             GenerateTokenResponseModel tokenResponse = await GenerateTokenAsync(privateKey, publicKeyStore, ecParameters, tokenState.P);
 
-            var token = service.RandomizeToken(tokenState, tokenResponse, await publicKeyStore.GetAsync());
+            var publicKey = (await publicKeyStore.GetAsync()).Q;
+            var token = service.RandomizeToken(tokenState, tokenResponse, publicKey);
             (await VerifyToken(privateKey, ecParameters, tokenState, token)).Should().BeTrue();
         }
 
@@ -44,7 +45,7 @@ namespace NDB.Covid19.Test.Tests.WebServices
             var privateKey = GeneratePrivateKey();
             GenerateTokenResponseModel tokenResponse = await GenerateTokenAsync(privateKey, publicKeyStore, ecParameters, tokenState.P);
 
-            var publicKey = await publicKeyStore.GetAsync();
+            var publicKey = (await publicKeyStore.GetAsync()).Q;
             Assert.Throws<AnonymousTokensException>(() => service.RandomizeToken(tokenState, tokenResponse, publicKey))
                 .Message.Should().Contain("proof is invalid");
         }
@@ -58,7 +59,8 @@ namespace NDB.Covid19.Test.Tests.WebServices
             GenerateTokenResponseModel tokenResponse = await GenerateTokenAsync(await inMemoryPrivateKeyStore.GetAsync(), publicKeyStore, ecParameters, tokenState.P);
 
             var privateKey = GeneratePrivateKey();
-            var token = service.RandomizeToken(tokenState, tokenResponse, await publicKeyStore.GetAsync());
+            var publicKey = (await publicKeyStore.GetAsync()).Q;
+            var token = service.RandomizeToken(tokenState, tokenResponse, publicKey);
             (await VerifyToken(privateKey, ecParameters, tokenState, token)).Should().BeFalse();
         }
 

--- a/NDB.Covid19/NDB.Covid19.Test/Tests/WebServices/AnonymousTokenServiceTest.cs
+++ b/NDB.Covid19/NDB.Covid19.Test/Tests/WebServices/AnonymousTokenServiceTest.cs
@@ -8,7 +8,6 @@ using Org.BouncyCastle.Asn1.X9;
 using Org.BouncyCastle.Crypto.EC;
 using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Math.EC;
-using Org.BouncyCastle.Utilities.Encoders;
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -77,14 +76,14 @@ namespace NDB.Covid19.Test.Tests.WebServices
             return await new TokenVerifier(new InMemorySeedStore()).VerifyTokenAsync(privateKey, ecParameters.Curve, tokenState.t, token);
         }
 
-        private async static Task<GenerateTokenResponseModel> GenerateTokenAsync(BigInteger privateKey, IPublicKeyStore publicKeyStore, X9ECParameters ecParameters, ECPoint P)
+        private static async Task<GenerateTokenResponseModel> GenerateTokenAsync(BigInteger privateKey, IPublicKeyStore publicKeyStore, X9ECParameters ecParameters, ECPoint P)
         {
             var response = new TokenGenerator().GenerateToken(privateKey, (await publicKeyStore.GetAsync()).Q, ecParameters, P);
             return new GenerateTokenResponseModel
             {
-                ProofCAsHex = Hex.ToHexString(response.c.ToByteArray()),
-                ProofZAsHex = Hex.ToHexString(response.z.ToByteArray()),
-                QAsHex = Hex.ToHexString(response.Q.GetEncoded())
+                ProofChallenge = Convert.ToBase64String(response.c.ToByteArray()),
+                ProofResponse = Convert.ToBase64String(response.z.ToByteArray()),
+                SignedPoint = Convert.ToBase64String(response.Q.GetEncoded())
             };
         }
     }

--- a/NDB.Covid19/NDB.Covid19/Models/PersonalDataModel.cs
+++ b/NDB.Covid19/NDB.Covid19/Models/PersonalDataModel.cs
@@ -32,7 +32,7 @@ namespace NDB.Covid19.Models
         [JsonIgnore]
         public bool UnknownStatus => Covid19_status == "ukendt";
         [JsonIgnore]
-        public bool AnonymousTokensEnabled => Covid19_anonymous_token == "v1:enabled";
+        public bool AnonymousTokensEnabled => Covid19_anonymous_token == "v1_enabled";
 
 
         public bool Validate()

--- a/NDB.Covid19/NDB.Covid19/Models/PersonalDataModel.cs
+++ b/NDB.Covid19/NDB.Covid19/Models/PersonalDataModel.cs
@@ -32,7 +32,7 @@ namespace NDB.Covid19.Models
         [JsonIgnore]
         public bool UnknownStatus => Covid19_status == "ukendt";
         [JsonIgnore]
-        public bool AnonymousTokensEnabled => Covid19_anonymous_token == "available";
+        public bool AnonymousTokensEnabled => Covid19_anonymous_token == "v1:enabled";
 
 
         public bool Validate()

--- a/NDB.Covid19/NDB.Covid19/NDB.Covid19.csproj
+++ b/NDB.Covid19/NDB.Covid19/NDB.Covid19.csproj
@@ -63,7 +63,7 @@
     <Folder Include="WebServices\ExposureNotification\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AnonymousTokens.Client" Version="1.3.0" />
+    <PackageReference Include="AnonymousTokens.Client" Version="2.0.0" />
     <PackageReference Include="AntiXSS.NetStandard" Version="0.1.111" />
     <PackageReference Include="AutoMapper" Version="5.1.1" />
     <PackageReference Include="I18NPortable" Version="1.0.1" />

--- a/NDB.Covid19/NDB.Covid19/WebServices/AnonymousTokenService.cs
+++ b/NDB.Covid19/NDB.Covid19/WebServices/AnonymousTokenService.cs
@@ -47,7 +47,7 @@ namespace NDB.Covid19.WebServices
             };
         }
 
-        public ECPoint RandomizeToken(AnonymousTokenState state, GenerateTokenResponseModel tokenResponse, ECPublicKeyParameters K)
+        public ECPoint RandomizeToken(AnonymousTokenState state, GenerateTokenResponseModel tokenResponse, ECPoint K)
         {
             var Q = _ecParameters.Curve.DecodePoint(Convert.FromBase64String(tokenResponse.SignedPoint));
             var c = new BigInteger(Convert.FromBase64String(tokenResponse.ProofChallenge));
@@ -78,7 +78,7 @@ namespace NDB.Covid19.WebServices
             return JsonConvert.DeserializeObject<GenerateTokenResponseModel>(await response.Content.ReadAsStringAsync());
         }
 
-        private async Task<ECPublicKeyParameters> GetPublicKeyAsync(GenerateTokenResponseModel tokenResponse)
+        private async Task<ECPoint> GetPublicKeyAsync(GenerateTokenResponseModel tokenResponse)
         {
             string kid = tokenResponse.Kid;
             var request = new HttpRequestMessage(HttpMethod.Get, OAuthConf.OAUTH2_ANONTOKEN_URL + "/atks");
@@ -91,14 +91,13 @@ namespace NDB.Covid19.WebServices
             return DecodePublicKey(anonTokenKeyStoreResponse.Keys.Single(k => k.Kid == kid));
         }
 
-        private static ECPublicKeyParameters DecodePublicKey(AnonymousTokenKey key)
+        private static ECPoint DecodePublicKey(AnonymousTokenKey key)
         {
             var curve = CustomNamedCurves.GetByName(key.Crv);
-            var clientSidePublicKeyPoint = curve.Curve.CreatePoint(
+            return curve.Curve.CreatePoint(
                 new BigInteger(Convert.FromBase64String(key.X)),
                 new BigInteger(Convert.FromBase64String(key.Y))
             );
-            return new ECPublicKeyParameters("ECDSA", clientSidePublicKeyPoint, new ECDomainParameters(curve));
         }
     }
 


### PR DESCRIPTION
Due to a released version of smittestopp with a broken implementation of AnonymousTokens currently disabled through an existing feature flag we will need change to a new feature flag for future releases to avoid activating broken functionality in already released versions.

Since we create a new feature flag, and will not activate any of the currently released versions of anonymous tokens, I included changing the property names to more readable names as suggested in the [anonymous tokens repo](https://github.com/HenrikWM/anonymous-tokens/#suggested-descriptive-variable-names)

I have also updated to the latest version of the anonymous token package, which simplifies some method signatures to use ECPoint instead of ECPublicKeyParameters.