### PR TITLE
WIP: Added Bokmål, Nynorsk and English

### DIFF
--- a/NDB.Covid19/NDB.Covid19/Locales/en.json
+++ b/NDB.Covid19/NDB.Covid19/Locales/en.json
@@ -1,6 +1,6 @@
 {
   "LAUNCHER_PAGE_START_BTN": "Start",
-  "LAUNCHER_PAGE_OS_VERSION_DIALOG_MESSAGE_IOS": "Smittestopp only functions if your iOS device is running version 13.6 or later. Please update to a later version than your current one. You do this in your phone's Settings -> General -> Software Update. ",
+  "LAUNCHER_PAGE_OS_VERSION_DIALOG_MESSAGE_IOS": "You need to update your phone to use Smittestopp. Go to Settings -> General -> Software Update. ",
   "BASE_ERROR_TITLE": "ERROR",
   "BASE_ERROR_MESSAGE": "An error occurred. Please try again later.",
   "ERROR_OK_BTN": "OK",

--- a/NDB.Covid19/NDB.Covid19/Locales/nb.json
+++ b/NDB.Covid19/NDB.Covid19/Locales/nb.json
@@ -1,6 +1,6 @@
 ﻿{
   "LAUNCHER_PAGE_START_BTN": "Start",
-  "LAUNCHER_PAGE_OS_VERSION_DIALOG_MESSAGE_IOS": "Smittestopp fungerer bare med iOS 13.6 eller nyere. Oppdater til en nyere versjon. Det gjør du på mobilen din under Innstillinger -> Generelt -> Programvareoppdatering. ",
+  "LAUNCHER_PAGE_OS_VERSION_DIALOG_MESSAGE_IOS": "Du må oppdatere telefonen din for å bruke Smittestopp. Gå til Innstillinger -> Generelt -> Programvareoppdatering. ",
   "BASE_ERROR_TITLE": "FEIL",
   "BASE_ERROR_MESSAGE": "Det oppsto en feil. Prøv igjen senere.",
   "ERROR_OK_BTN": "OK",

--- a/NDB.Covid19/NDB.Covid19/Locales/nn.json
+++ b/NDB.Covid19/NDB.Covid19/Locales/nn.json
@@ -1,6 +1,6 @@
 ﻿{
   "LAUNCHER_PAGE_START_BTN": "Start",
-  "LAUNCHER_PAGE_OS_VERSION_DIALOG_MESSAGE_IOS": "Smittestopp fungerer berre med iOS 13.6 eller nyare. Oppdater til ein nyare versjon. Det gjer du på mobilen din under Innstillingar -> Generelt -> Programvareoppdatering. ",
+  "LAUNCHER_PAGE_OS_VERSION_DIALOG_MESSAGE_IOS": "Du må oppdatere telefonen din for å bruke Smittestopp. Gå til Innstillingar -> Generelt -> Programvareoppdatering. ",
   "BASE_ERROR_TITLE": "FEIL",
   "BASE_ERROR_MESSAGE": "Noko gjekk gale. Prøv på nytt seinare.",
   "ERROR_OK_BTN": "OK",


### PR DESCRIPTION
New texts for users who might end up installing Smittestop on unsupported version of iOS.