### PR TITLE
[55323] Fix crash on countries list not being loaded

### DIFF
--- a/NDB.Covid19/NDB.Covid19.iOS/Views/AuthenticationFlow/QuestionnaireCountries/QuestionnaireCountriesViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/AuthenticationFlow/QuestionnaireCountries/QuestionnaireCountriesViewController.cs
@@ -33,6 +33,7 @@ namespace NDB.Covid19.iOS.Views.AuthenticationFlow.QuestionnaireCountries
             base.ViewDidLoad();
 
             _viewModel = new QuestionnaireCountriesViewModel();
+            _countryList = new List<CountryDetailsViewModel>();
 
             SetStyling();
             SetAccessibility();


### PR DESCRIPTION
Initializing empty list of countries when view is loaded to prevent a null pointer caused crash if user clicks submit button before the countries list is loaded