### PR TITLE
[iOS] Made labels that display total numbers in boxes not visible for release 2.2

### DIFF
--- a/NDB.Covid19/NDB.Covid19.iOS/Views/DailyNumbers/DailyNumbers.storyboard
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/DailyNumbers/DailyNumbers.storyboard
@@ -389,7 +389,7 @@
                                                                                         <nil key="highlightedColor"/>
                                                                                     </label>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Total number" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WRL-i3-xEC" userLabel="Daily Numbers Number6 Lbl">
-                                                                                        <rect key="frame" x="0.0" y="102" width="85" height="17"/>
+                                                                                        <rect key="frame" x="0.0" y="79.5" width="85" height="39.5"/>
                                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                                         <color key="textColor" systemColor="systemYellowColor"/>
                                                                                         <nil key="highlightedColor"/>
@@ -418,13 +418,13 @@
                                                                                         <nil key="highlightedColor"/>
                                                                                     </label>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Total number" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Meh-Oj-gTx" userLabel="Daily Numbers Number5 Lbl">
-                                                                                        <rect key="frame" x="0.0" y="79" width="85" height="17"/>
+                                                                                        <rect key="frame" x="0.0" y="79.5" width="85" height="17"/>
                                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                                         <color key="textColor" systemColor="systemYellowColor"/>
                                                                                         <nil key="highlightedColor"/>
                                                                                     </label>
                                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Infected" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ubU-j6-5GM" userLabel="Total Daily Numbers Number5 Lbl">
-                                                                                        <rect key="frame" x="0.0" y="104" width="46.5" height="15"/>
+                                                                                        <rect key="frame" x="0.0" y="104.5" width="46.5" height="14.5"/>
                                                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                         <nil key="highlightedColor"/>
@@ -445,7 +445,7 @@
                                                                     </view>
                                                                 </subviews>
                                                                 <constraints>
-                                                                    <constraint firstItem="WRL-i3-xEC" firstAttribute="firstBaseline" secondItem="ubU-j6-5GM" secondAttribute="firstBaseline" id="lB7-hn-xDY"/>
+                                                                    <constraint firstItem="WRL-i3-xEC" firstAttribute="firstBaseline" secondItem="Meh-Oj-gTx" secondAttribute="firstBaseline" id="9a5-0v-6eE"/>
                                                                     <constraint firstItem="MlL-gZ-ANI" firstAttribute="firstBaseline" secondItem="X7N-0k-vjA" secondAttribute="firstBaseline" id="tbc-Lr-dn9"/>
                                                                 </constraints>
                                                             </stackView>

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/DailyNumbers/DailyNumbersViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/DailyNumbers/DailyNumbersViewController.cs
@@ -41,8 +41,8 @@ namespace NDB.Covid19.iOS.Views.DailyNumbers
 		// NOTE: This is late time change to release 2.2, delete this function and call to it when
 		// decision to display them is made in future releases. Note that underlying data is still
 		// available in preferences.
-        private void HideTotals()
-        {
+		private void HideTotals()
+		{
 			TotalDailyNumbersNumber1Lbl.Hidden = true;
 			TotalDailyNumbersNumber3Lbl.Hidden = true;
 			TotalDailyNumbersNumber5Lbl.Hidden = true;
@@ -50,7 +50,7 @@ namespace NDB.Covid19.iOS.Views.DailyNumbers
 			TotalDailyNumbersNumber10Lbl.Hidden = true;
 		}
 
-        private void SetStyling()
+		private void SetStyling()
 		{
 			// Set background color and corner radius for views
 			DailyNumbersView1.BackgroundColor = ColorHelper.PRIMARY_COLOR;

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/DailyNumbers/DailyNumbersViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/DailyNumbers/DailyNumbersViewController.cs
@@ -30,11 +30,27 @@ namespace NDB.Covid19.iOS.Views.DailyNumbers
 			base.ViewDidLoad();
 
 			SetStyling();
+
+			//Remove labels with total numbers from boxes in release 2.2
+			HideTotals();
+
 			MessagingCenter.Subscribe<object>(this, MessagingCenterKeys.KEY_APP_RETURNS_FROM_BACKGROUND, OnAppReturnsFromBackground);
 			UIAccessibility.PostNotification(UIAccessibilityPostNotification.ScreenChanged, DailyNumbersTitleOne);
 		}
 
-		private void SetStyling()
+		// NOTE: This is late time change to release 2.2, delete this function and call to it when
+		// decision to display them is made in future releases. Note that underlying data is still
+		// available in preferences.
+        private void HideTotals()
+        {
+			TotalDailyNumbersNumber1Lbl.Hidden = true;
+			TotalDailyNumbersNumber3Lbl.Hidden = true;
+			TotalDailyNumbersNumber5Lbl.Hidden = true;
+			TotalDailyNumbersNumber9Lbl.Hidden = true;
+			TotalDailyNumbersNumber10Lbl.Hidden = true;
+		}
+
+        private void SetStyling()
 		{
 			// Set background color and corner radius for views
 			DailyNumbersView1.BackgroundColor = ColorHelper.PRIMARY_COLOR;


### PR DESCRIPTION
## iPhone SE2
<img width="300" alt="image" src="https://user-images.githubusercontent.com/14860255/111778616-38e63080-88b5-11eb-8278-dc7e568e35ae.png">

## iPhone 5S
<img width="300" alt="image" src="https://user-images.githubusercontent.com/14860255/111778826-94b0b980-88b5-11eb-8116-34e0d22a7b04.png">

## iPhone XS Max
<img width="300" alt="image" src="https://user-images.githubusercontent.com/14860255/111779117-00932200-88b6-11eb-9542-86ec8c739013.png">



