### PR TITLE
[55817] Switched default date representation to nynorsk culture

### DIFF
--- a/NDB.Covid19/NDB.Covid19/Configuration/Conf.cs
+++ b/NDB.Covid19/NDB.Covid19/Configuration/Conf.cs
@@ -26,7 +26,7 @@ namespace NDB.Covid19.Configuration
         //It takes around 25 seconds to download a zip file with 100.000 keys if you have 3G connection.
         //The timeout value takes this into consideration.
         public static int DEFAULT_TIMEOUT_SERVICECALLS_SECONDS => 40;
-        public static string DEFAULT_LANGUAGE = "nb"; //In case the device is set to use an unsupported language
+        public static string DEFAULT_LANGUAGE = "nn"; //In case the device is set to use an unsupported language
         public static string[] SUPPORTED_LANGUAGES = new string[] { "en", "nb", "nn", "pl", "so", "ti", "ar", "ur", "lt" };
 
         public static int MESSAGE_RETENTION_TIME_IN_MINUTES_SHORT => 15; 

--- a/NDB.Covid19/NDB.Covid19/Utils/DateUtils.cs
+++ b/NDB.Covid19/NDB.Covid19/Utils/DateUtils.cs
@@ -16,8 +16,9 @@ namespace NDB.Covid19.Utils
                 DateTime dateTime = (DateTime)date;
                 string appLanguage = LocalPreferencesHelper.GetAppLanguage();
                 CultureInfo selectedCulture = CultureInfo.GetCultureInfo(appLanguage);
-                CultureInfo defaultCulture = CultureInfo.GetCultureInfo(Conf.DEFAULT_LANGUAGE);
-                bool shouldUseDefaultCulture = appLanguage == "ar" || appLanguage == "ur" || appLanguage == "ti";
+                // Due to a bug in C# string representation in nb culture, nn must be used
+                CultureInfo defaultCalendarCulture = CultureInfo.GetCultureInfo("nn");
+                bool shouldUseDefaultCulture = appLanguage == "ar" || appLanguage == "ur" || appLanguage == "ti" || appLanguage == "nb";
                 string dateString;
                 DateTime calenderDateTime = new DateTime(
                     dateTime.Year,
@@ -28,7 +29,7 @@ namespace NDB.Covid19.Utils
                     dateTime.Second,
                     dateTime.Millisecond,
                     new GregorianCalendar());
-                dateString = calenderDateTime.ToString(dateFormat,shouldUseDefaultCulture ? defaultCulture : selectedCulture);
+                dateString = calenderDateTime.ToString(dateFormat,shouldUseDefaultCulture ? defaultCalendarCulture : selectedCulture);
                 return dateString.Replace("-", ".");
             }
             else

--- a/NDB.Covid19/NDB.Covid19/Utils/DateUtils.cs
+++ b/NDB.Covid19/NDB.Covid19/Utils/DateUtils.cs
@@ -17,7 +17,7 @@ namespace NDB.Covid19.Utils
                 string appLanguage = LocalPreferencesHelper.GetAppLanguage();
                 CultureInfo selectedCulture = CultureInfo.GetCultureInfo(appLanguage);
                 // Due to a bug in C# string representation in nb culture, nn must be used
-                CultureInfo defaultCalendarCulture = CultureInfo.GetCultureInfo("nn");
+                CultureInfo defaultCulture = CultureInfo.GetCultureInfo(Conf.DEFAULT_LANGUAGE);
                 bool shouldUseDefaultCulture = appLanguage == "ar" || appLanguage == "ur" || appLanguage == "ti" || appLanguage == "nb";
                 string dateString;
                 DateTime calenderDateTime = new DateTime(
@@ -29,7 +29,7 @@ namespace NDB.Covid19.Utils
                     dateTime.Second,
                     dateTime.Millisecond,
                     new GregorianCalendar());
-                dateString = calenderDateTime.ToString(dateFormat,shouldUseDefaultCulture ? defaultCalendarCulture : selectedCulture);
+                dateString = calenderDateTime.ToString(dateFormat, shouldUseDefaultCulture ? defaultCulture : selectedCulture);
                 return dateString.Replace("-", ".");
             }
             else


### PR DESCRIPTION
This is done because of a bug in C# string representation of DateTime objects when using bokmål culture