### PR TITLE
Bugfix - Incorrect word splitting in Bokmal - Key figures page

### DIFF
--- a/NDB.Covid19/NDB.Covid19.iOS/Views/DailyNumbers/DailyNumbersViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/DailyNumbers/DailyNumbersViewController.cs
@@ -96,7 +96,7 @@ namespace NDB.Covid19.iOS.Views.DailyNumbers
 			StyleUtil.InitLabelWithSpacing(KeyFeature3Lbl, StyleUtil.FontType.FontRegular, KEY_FEATURE_THREE_LABEL, 1.14, 16, 18);
 			KeyFeature3Lbl.TextColor = ColorHelper.TEXT_COLOR_ON_PRIMARY;
 			
-			StyleUtil.InitLabelWithSpacing(KeyFeature4Lbl, StyleUtil.FontType.FontRegular, KEY_FEATURE_FOUR_LABEL, 1.14, 16, 18);
+			StyleUtil.InitLabelWithSpacing(KeyFeature4Lbl, StyleUtil.FontType.FontRegular, KEY_FEATURE_FOUR_LABEL, 1.14, 16, 18, false, true);
 			KeyFeature4Lbl.TextColor = ColorHelper.TEXT_COLOR_ON_PRIMARY;
 
 			StyleUtil.InitLabelWithSpacing(KeyFeature6Lbl, StyleUtil.FontType.FontRegular, KEY_FEATURE_SIX_LABEL, 1.14, 16, 18);


### PR DESCRIPTION
Added text hyphenation to one text label.

Before:
![image](https://user-images.githubusercontent.com/70844214/122734419-5a710280-d27e-11eb-965c-a0bc43e30de2.png)
After:
![IMG_1584](https://user-images.githubusercontent.com/70844214/122734460-6361d400-d27e-11eb-9730-f7f5c058b574.PNG)
