### PR TITLE
[Bugfix] - Android - fixed alignment of date for new messages

### DIFF
--- a/NDB.Covid19/NDB.Covid19.Droid/Views/Messages/MessagesAdapter.cs
+++ b/NDB.Covid19/NDB.Covid19.Droid/Views/Messages/MessagesAdapter.cs
@@ -38,6 +38,7 @@ namespace NDB.Covid19.Droid.Views.Messages
             title.SetAccessibilityDelegate(AccessibilityUtils.GetHeadingAccessibilityDelegate());
             view.FindViewById<TextView>(Resource.Id.new_item).Text = MessagesViewModel.MESSAGES_NEW_ITEM;
             view.FindViewById<TextView>(Resource.Id.messages_item_date).Text = _items[position].DayAndMonthString;
+            view.FindViewById<TextView>(Resource.Id.messages_item_date).TextAlignment = TextAlignment.ViewStart;
             view.FindViewById<TextView>(Resource.Id.messages_item_description).Text = MessageItemViewModel.MESSAGES_RECOMMENDATIONS;
             view.FindViewById<LinearLayout>(Resource.Id.dot_layout).Visibility =
                 _items[position].IsRead

--- a/NDB.Covid19/NDB.Covid19.Droid/Views/Messages/MessagesAdapter.cs
+++ b/NDB.Covid19/NDB.Covid19.Droid/Views/Messages/MessagesAdapter.cs
@@ -34,11 +34,12 @@ namespace NDB.Covid19.Droid.Views.Messages
         {
             View view = convertView ?? _context.LayoutInflater.Inflate(Resource.Layout.messages_list_element, null);
             TextView title = view.FindViewById<TextView>(Resource.Id.messages_item_title);
+            TextView dateView = view.FindViewById<TextView>(Resource.Id.messages_item_date);
             title.Text = _items[position].Title.Translate();
             title.SetAccessibilityDelegate(AccessibilityUtils.GetHeadingAccessibilityDelegate());
             view.FindViewById<TextView>(Resource.Id.new_item).Text = MessagesViewModel.MESSAGES_NEW_ITEM;
-            view.FindViewById<TextView>(Resource.Id.messages_item_date).Text = _items[position].DayAndMonthString;
-            view.FindViewById<TextView>(Resource.Id.messages_item_date).TextAlignment = TextAlignment.ViewStart;
+            dateView.Text = _items[position].DayAndMonthString;
+            dateView.TextAlignment = TextAlignment.ViewStart;
             view.FindViewById<TextView>(Resource.Id.messages_item_description).Text = MessageItemViewModel.MESSAGES_RECOMMENDATIONS;
             view.FindViewById<LinearLayout>(Resource.Id.dot_layout).Visibility =
                 _items[position].IsRead

--- a/NDB.Covid19/NDB.Covid19.Test/NDB.Covid19.Test.csproj
+++ b/NDB.Covid19/NDB.Covid19.Test/NDB.Covid19.Test.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="AnonymousTokens.Server" Version="2.0.0" />
-    <PackageReference Include="chilkat-x64" Version="9.5.0.86" />
+    <PackageReference Include="chilkat-x64" Version="9.5.0.87" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />


### PR DESCRIPTION
Fixed alignment of date in infection message window for arabic and urdu. 
![Screenshot_20210630-121450_Smittestopp](https://user-images.githubusercontent.com/70844214/123943988-f4326100-d99c-11eb-9f61-411758881d6e.jpg)
