### PR TITLE
[65584][Bugfix] - Navigate to correct destination when exiting authflow

### DIFF
--- a/NDB.Covid19/NDB.Covid19.Droid/Views/AuthenticationFlow/InformationAndConsentActivity.cs
+++ b/NDB.Covid19/NDB.Covid19.Droid/Views/AuthenticationFlow/InformationAndConsentActivity.cs
@@ -122,7 +122,7 @@ namespace NDB.Covid19.Droid.Views.AuthenticationFlow
             _notificationHeader.SetAccessibilityDelegate(AccessibilityUtils.GetHeadingAccessibilityDelegate());
 
             //Button click events
-            _closeButton.Click += new SingleClick((sender, e) => Finish(), 500).Run;
+            _closeButton.Click += new SingleClick((sender, e) => GoToInfectionStatusPage(), 500).Run;
             _idPortenButton.Click += new SingleClick(LogInWithIDPortenButton_Click, 500).Run;
 
             //Progress bar
@@ -188,5 +188,7 @@ namespace NDB.Covid19.Droid.Views.AuthenticationFlow
                 _progressBar.Visibility = ViewStates.Gone;
             }
         }
+
+        private void GoToInfectionStatusPage() => NavigationHelper.GoToResultPageAndClearTop(this);
     }
 }

--- a/NDB.Covid19/NDB.Covid19.iOS/Views/SelftestOption/SelftestOptionViewController.cs
+++ b/NDB.Covid19/NDB.Covid19.iOS/Views/SelftestOption/SelftestOptionViewController.cs
@@ -77,19 +77,13 @@ namespace NDB.Covid19.iOS.Views.SelftestOption
 
         partial void ContinueWithMSISBtn_TouchUpInside(UIKit.UIButton sender)
         {
-            UINavigationController navigationController = new UINavigationController(InformationAndConsentViewController.GetInformationAndConsentViewController());
-            navigationController.SetNavigationBarHidden(true, false);
-            navigationController.ModalPresentationStyle = UIModalPresentationStyle.FullScreen;
-            PresentViewController(navigationController, true, null);
+            NavigationController?.PushViewController(InformationAndConsentViewController.GetInformationAndConsentViewController(), true);
             IsReportingSelfTest = false;
         }
 
         partial void ContinueWithSelftestBtn_TouchUpInside(UIKit.UIButton sender)
         {
-            UINavigationController navigationController = new UINavigationController(InformationAndConsentViewController.GetInformationAndConsentViewController());
-            navigationController.SetNavigationBarHidden(true, false);
-            navigationController.ModalPresentationStyle = UIModalPresentationStyle.FullScreen;
-            PresentViewController(navigationController, true, null);
+            NavigationController?.PushViewController(InformationAndConsentViewController.GetInformationAndConsentViewController(), true);
             IsReportingSelfTest = true;
         }
 


### PR DESCRIPTION
* Fix issue where exiting auth-flow did not return to infection status page – iOS
* Pop to infection status page when exiting from information consent – Android 