### PR TITLE
[Bugfix][65644] - Prevent auth-flow aborting when proceeding with empty symptoms date

### DIFF
--- a/NDB.Covid19/NDB.Covid19.Droid/Views/AuthenticationFlow/QuestionnairePageActivity.cs
+++ b/NDB.Covid19/NDB.Covid19.Droid/Views/AuthenticationFlow/QuestionnairePageActivity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Android.App;
@@ -261,9 +261,7 @@ namespace NDB.Covid19.Droid.Views.AuthenticationFlow
 
         void OnValidationFail()
         {
-            AuthErrorUtils.GoToTechnicalError(this, LogSeverity.ERROR, null,
-                $"{nameof(QuestionnaireCountriesSelectionActivity)}.{nameof(OnFail)}: " +
-                "AuthenticationState.personaldata is not valid (Android)");
+            LogUtils.LogMessage(LogSeverity.INFO, $"{nameof(QuestionnairePageActivity)}.{nameof(OnFail)}: Failed to validate selected date.", null, GetCorrelationId());
         }
 
         private void OnInfoButtonPressed(object o, EventArgs args)


### PR DESCRIPTION
* Fixed an issue where selecting `YesSince` from the symptoms date questionnaire without specifying a date, the registration flow got aborted. It will instead now show an error msg to indicate that the user must specify a date to continue.

