### PR TITLE
[66169][Android] Bugfix - Alert theme

### DIFF
--- a/NDB.Covid19/NDB.Covid19.Droid/Utils/DialogUtils.cs
+++ b/NDB.Covid19/NDB.Covid19.Droid/Utils/DialogUtils.cs
@@ -48,7 +48,7 @@ namespace NDB.Covid19.Droid.Utils
                 return tcs.Task;
             }
 
-            var dialog = new AlertDialog.Builder(activity, Android.Resource.Style.ThemeDeviceDefaultLightDialog)
+            var dialog = new AlertDialog.Builder(activity)
               .SetTitle(title)
               .SetMessage(message)
               .SetCancelable(false);
@@ -138,7 +138,11 @@ namespace NDB.Covid19.Droid.Utils
             }
         }
 
-        public static async Task<bool> DisplayDialogAsync(Activity current, DialogViewModel viewModel, Action actionOk = null, Action actionNotOk = null)
+        public static async Task<bool> DisplayDialogAsync(
+            Activity current,
+            DialogViewModel viewModel,
+            Action actionOk = null,
+            Action actionNotOk = null)
         {
             TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
             if (current == null || current.IsFinishing)


### PR DESCRIPTION
Use default theme for android alert dialog in DialogUtils. To match rest of dialogs and show correctly in dark mode on OneUI (Samsung).
<img src="https://user-images.githubusercontent.com/97104440/155342706-c2378cf8-91d5-48d3-9a31-7372285cdd8f.png" width="256">
